### PR TITLE
Add header/footer templates and dashboard page

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -4,15 +4,19 @@ bp = Blueprint('main', __name__)
 
 @bp.route('/')
 def greeting():
-    return render_template('greeting.html')
+    return render_template('greeting.html', title='Greeting')
 
 @bp.route('/login')
 def login():
-    return render_template('login.html')
+    return render_template('login.html', title='Login')
 
 @bp.route('/home')
 def home():
-    return render_template('home.html')
+    return render_template('home.html', title='Home')
+
+@bp.route('/dashboard')
+def dashboard():
+    return render_template('dashboard.html', title='Dashboard')
 
 @bp.route('/greet/<name>')
 def greet(name):

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,4 @@
+{% include 'header.html' %}
+<h1>Dashboard Page</h1>
+<p>This is the new dashboard.</p>
+{% include 'footer.html' %}

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,0 +1,5 @@
+    <footer>
+        <p>&copy; 2023 DataWasher</p>
+    </footer>
+</body>
+</html>

--- a/templates/greeting.html
+++ b/templates/greeting.html
@@ -1,7 +1,3 @@
-<!doctype html>
-<html>
-<head><title>Greeting</title></head>
-<body>
-    <h1>Welcome!</h1>
-</body>
-</html>
+{% include 'header.html' %}
+<h1>Welcome!</h1>
+{% include 'footer.html' %}

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<head>
+    <title>{{ title|default('DataWasher') }}</title>
+</head>
+<body>
+    <header>
+        <nav>
+            <a href="{{ url_for('main.greeting') }}">Greeting</a>
+            <a href="{{ url_for('main.login') }}">Login</a>
+            <a href="{{ url_for('main.home') }}">Home</a>
+            <a href="{{ url_for('main.dashboard') }}">Dashboard</a>
+        </nav>
+    </header>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,7 +1,3 @@
-<!doctype html>
-<html>
-<head><title>Home</title></head>
-<body>
-    <h1>Home Page</h1>
-</body>
-</html>
+{% include 'header.html' %}
+<h1>Home Page</h1>
+{% include 'footer.html' %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,7 +1,3 @@
-<!doctype html>
-<html>
-<head><title>Login</title></head>
-<body>
-    <h1>Login Page</h1>
-</body>
-</html>
+{% include 'header.html' %}
+<h1>Login Page</h1>
+{% include 'footer.html' %}


### PR DESCRIPTION
## Summary
- add reusable `header.html` with navigation links
- add `footer.html`
- update existing templates to include the header and footer
- add new `dashboard.html` page
- connect new dashboard route and pass page titles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603f5c465c8327a0bcdf46c52c1021