### PR TITLE
Separate JavaScript logic from template

### DIFF
--- a/static/js/one_hour_report.js
+++ b/static/js/one_hour_report.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const canvas = document.getElementById('pieChart');
+    if (!canvas) return;
+    const labels = JSON.parse(canvas.dataset.labels);
+    const values = JSON.parse(canvas.dataset.values);
+    const data = {
+        labels: labels,
+        datasets: [{
+            data: values,
+            backgroundColor: [
+                '#4F46E5', '#9333EA', '#059669',
+                '#F59E0B', '#EF4444', '#3B82F6'
+            ]
+        }]
+    };
+    new Chart(canvas, {
+        type: 'pie',
+        data: data,
+        options: { responsive: true }
+    });
+});

--- a/templates/pages/one_hour_report.html
+++ b/templates/pages/one_hour_report.html
@@ -31,25 +31,11 @@
         </tbody>
     </table>
 
-    <canvas id="pieChart" class="mx-auto" height="300"></canvas>
+    <canvas id="pieChart" class="mx-auto" height="300"
+            data-labels="{{ chart_labels|safe }}"
+            data-values="{{ chart_values|safe }}"></canvas>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script>
-        const ctx = document.getElementById('pieChart');
-        const data = {
-            labels: {{ chart_labels|safe }},
-            datasets: [{
-                data: {{ chart_values|safe }},
-                backgroundColor: [
-                    '#4F46E5', '#9333EA', '#059669', '#F59E0B', '#EF4444', '#3B82F6'
-                ],
-            }]
-        };
-        new Chart(ctx, {
-            type: 'pie',
-            data: data,
-            options: { responsive: true }
-        });
-    </script>
+    <script src="{{ url_for('static', filename='js/one_hour_report.js') }}"></script>
     {% endif %}
 </div>
 {% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- move the pie chart logic to `static/js/one_hour_report.js`
- reference the external script from `one_hour_report.html`
- pass chart data via `data-` attributes

## Testing
- `python3 -m py_compile app.py routes.py`

------
https://chatgpt.com/codex/tasks/task_e_6860586a11888327bb20cd70835e9821