### PR TITLE
Add simple session auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 A simple Flask application skeleton.
 
-This project includes simple pages for creating a user and logging in. These
-forms demonstrate basic form handling but do not implement real authentication.
+The project now contains a very small authentication system.  Users can log in
+using the credentials `admin` / `secret`.  When logged in a session cookie is
+set and the **Dashboard** and **1‑Hour Report** pages become available.  Logging
+out clears the session and redirects back to the login page.
 
 ## Template structure
 

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from routes import bp
 
 def create_app():
     app = Flask(__name__)
+    app.secret_key = "change-me"  # simple secret for session management
     app.register_blueprint(bp)
     return app
 

--- a/routes.py
+++ b/routes.py
@@ -1,7 +1,19 @@
-from flask import Blueprint, render_template, request
+from functools import wraps
+from flask import Blueprint, render_template, request, redirect, url_for, session
 from logic.one_hour_report import process_one_hour_report_file
 
 bp = Blueprint('main', __name__)
+
+
+def login_required(view_func):
+    """Simple decorator to require authentication."""
+    @wraps(view_func)
+    def wrapped_view(*args, **kwargs):
+        if not session.get('logged_in'):
+            return redirect(url_for('main.login', next=request.path))
+        return view_func(*args, **kwargs)
+
+    return wrapped_view
 
 @bp.route('/')
 def greeting():
@@ -12,8 +24,19 @@ def login():
     message = None
     if request.method == 'POST':
         username = request.form.get('username')
-        message = f"Logged in as {username}"
+        password = request.form.get('password')
+        if username == 'admin' and password == 'secret':
+            session['logged_in'] = True
+            next_url = request.args.get('next') or url_for('main.dashboard')
+            return redirect(next_url)
+        message = 'Invalid credentials'
     return render_template('pages/login.html', title='Login', message=message)
+
+
+@bp.route('/logout')
+def logout():
+    session.clear()
+    return redirect(url_for('main.login'))
 
 @bp.route('/create-user', methods=['GET', 'POST'])
 def create_user():
@@ -28,10 +51,12 @@ def home():
     return render_template('pages/home.html', title='Home')
 
 @bp.route('/dashboard')
+@login_required
 def dashboard():
     return render_template('pages/dashboard.html', title='Dashboard')
 
 @bp.route('/1-hour-report', methods=['GET', 'POST'])
+@login_required
 def one_hour_report():
     message = None
     table_data = None

--- a/templates/elements/header.html
+++ b/templates/elements/header.html
@@ -9,7 +9,11 @@
     <header class="fixed top-0 left-0 w-full bg-gray-100 shadow py-2">
         <nav class="flex space-x-4 px-4">
             <a class="text-blue-600" href="{{ url_for('main.greeting') }}">Greeting</a>
-            <a class="text-blue-600" href="{{ url_for('main.login') }}">Login</a>
+            {% if session.get('logged_in') %}
+                <a class="text-blue-600" href="{{ url_for('main.logout') }}">Logout</a>
+            {% else %}
+                <a class="text-blue-600" href="{{ url_for('main.login') }}">Login</a>
+            {% endif %}
             <a class="text-blue-600" href="{{ url_for('main.create_user') }}">Create User</a>
             <a class="text-blue-600" href="{{ url_for('main.home') }}">Home</a>
             <a class="text-blue-600" href="{{ url_for('main.dashboard') }}">Dashboard</a>


### PR DESCRIPTION
## Summary
- add a SECRET_KEY and session-based login/logout routes
- require login for dashboard and report
- show login/logout in header
- document new simple authentication system

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68606767782c8327886b37c44775452f