### PR TITLE
Add DATABASE_URL config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ The application relies on a few environment variables:
 - `DEBUG` &mdash; set to `1` to enable debug mode when running locally.
 - `HOST` &mdash; hostname to bind the development server to.
 - `PORT` &mdash; port number for the server (defaults to `5000`).
+- `DATABASE_URL` &mdash; optional SQLAlchemy database URI. If absent, a local
+  SQLite database is used. Heroku populates this when a Postgres addon is
+  attached.
 
 For local development, create a `.env` file in the project root and define
 these variables. Load them into your shell before starting the app so `app.py`

--- a/app.py
+++ b/app.py
@@ -11,7 +11,10 @@ load_dotenv()
 def create_app():
     app = Flask(__name__)
     app.config["SECRET_KEY"] = os.getenv("SECRET_KEY")
-    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///datawasher.db"
+    database_uri = os.getenv("DATABASE_URL", "sqlite:///datawasher.db")
+    if database_uri.startswith("postgres://"):
+        database_uri = database_uri.replace("postgres://", "postgresql://", 1)
+    app.config["SQLALCHEMY_DATABASE_URI"] = database_uri
 
     db.init_app(app)
     login_manager.init_app(app)


### PR DESCRIPTION
## Summary
- allow DATABASE_URL to override the SQLAlchemy URI
- document DATABASE_URL in README

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo "py_compile success"`
- `pip install -r requirements.txt` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6860c06ed2a88327a6e960d779dc2c09