### PR TITLE
Use Heroku PostgreSQL only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,6 @@ htmlcov/
 .pytest_cache/
 
 # Heroku-related (optional - if you're not committing compiled builds)
-*.sqlite3
-*.db
 
 # Node-related (only if you're adding JS front-end)
 node_modules/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple Flask application skeleton.
 
-Authentication is backed by a small SQLite database.  Users can be created from
+Authentication is backed by a Heroku Postgres database.  Users can be created from
 the **Create User** page and then sign in using the login form.  Once
 authenticated the **Dashboard** and **1‑Hour Report** pages become available.
 Logging out clears the session and redirects back to the login page.
@@ -25,9 +25,9 @@ The application relies on a few environment variables:
 - `DEBUG` &mdash; set to `1` to enable debug mode when running locally.
 - `HOST` &mdash; hostname to bind the development server to.
 - `PORT` &mdash; port number for the server (defaults to `5000`).
-- `DATABASE_URL` &mdash; optional SQLAlchemy database URI. If absent, a local
-  SQLite database is used. Heroku populates this when a Postgres addon is
-  attached.
+- `DATABASE_URL` &mdash; SQLAlchemy database URI for the Heroku PostgreSQL
+  database. This variable is required and Heroku populates it automatically
+  when a Postgres addon is attached.
 
 For local development, create a `.env` file in the project root and define
 these variables. Load them into your shell before starting the app so `app.py`

--- a/app.py
+++ b/app.py
@@ -11,7 +11,9 @@ load_dotenv()
 def create_app():
     app = Flask(__name__)
     app.config["SECRET_KEY"] = os.getenv("SECRET_KEY")
-    database_uri = os.getenv("DATABASE_URL", "sqlite:///datawasher.db")
+    database_uri = os.getenv("DATABASE_URL")
+    if not database_uri:
+        raise RuntimeError("DATABASE_URL must be set to a Heroku Postgres URI")
     if database_uri.startswith("postgres://"):
         database_uri = database_uri.replace("postgres://", "postgresql://", 1)
     app.config["SQLALCHEMY_DATABASE_URI"] = database_uri


### PR DESCRIPTION
## Summary
- require `DATABASE_URL` in `app.py` and raise error if not set
- update README instructions to mention only Heroku PostgreSQL
- remove SQLite references from `.gitignore`

## Testing
- `python -m py_compile app.py models.py routes.py logic/one_hour_report.py`

------
https://chatgpt.com/codex/tasks/task_e_6860c8eaee7883278678a1fcd254e273