### PR TITLE
Fix password hash length

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,10 @@ web: gunicorn app:app
 Create a Heroku application, set the required environment variables (such as
 `SECRET_KEY`) and push the code. Heroku will run the command from the Procfile
 to serve the application.
+
+## Database schema
+
+The `User` model stores password hashes using Werkzeug's
+`generate_password_hash` which can produce strings longer than 128
+characters. The `password_hash` column therefore uses `String(255)` to
+avoid truncation errors when inserting new users.

--- a/models.py
+++ b/models.py
@@ -11,7 +11,7 @@ login_manager.login_view = 'main.login'
 class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
-    password_hash = db.Column(db.String(128), nullable=False)
+    password_hash = db.Column(db.String(255), nullable=False)
 
     def set_password(self, password: str) -> None:
         self.password_hash = generate_password_hash(password)


### PR DESCRIPTION
## Summary
- store password hashes with String(255) so password creation works on Heroku
- document new `password_hash` column length in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6860cb0b430083279a68ed602abddcfe