### PR TITLE
Allow SQLite fallback and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,22 @@ The application relies on a few environment variables:
 - `DEBUG` &mdash; set to `1` to enable debug mode when running locally.
 - `HOST` &mdash; hostname to bind the development server to.
 - `PORT` &mdash; port number for the server (defaults to `5000`).
-- `DATABASE_URL` &mdash; SQLAlchemy database URI for the Heroku PostgreSQL
-  database. This variable is required and Heroku populates it automatically
+- `DATABASE_URL` &mdash; SQLAlchemy database URI. If unset, the application
+  falls back to `sqlite:///data.db`. Heroku sets this variable automatically
   when a Postgres addon is attached.
 
 For local development, create a `.env` file in the project root and define
-these variables. Load them into your shell before starting the app so `app.py`
-can read them via `os.getenv`.
+these variables. The app uses **python-dotenv** to load them automatically
+when `app.py` is executed.
 
 ## Running the app locally
 
-Install the dependencies and start the server:
+Install the dependencies. To use SQLite instead of Postgres, set the database
+URL and then start the server:
 
 ```bash
 pip install -r requirements.txt
+export DATABASE_URL=sqlite:///data.db  # optional
 python app.py
 ```
 

--- a/app.py
+++ b/app.py
@@ -13,7 +13,8 @@ def create_app():
     app.config["SECRET_KEY"] = os.getenv("SECRET_KEY")
     database_uri = os.getenv("DATABASE_URL")
     if not database_uri:
-        raise RuntimeError("DATABASE_URL must be set to a Heroku Postgres URI")
+        # Fall back to a local SQLite database when running outside Heroku
+        database_uri = "sqlite:///data.db"
     if database_uri.startswith("postgres://"):
         database_uri = database_uri.replace("postgres://", "postgresql://", 1)
     app.config["SQLALCHEMY_DATABASE_URI"] = database_uri


### PR DESCRIPTION
## Summary
- default to SQLite when DATABASE_URL is unset
- document python-dotenv usage
- explain how to run locally with SQLite

## Testing
- `pytest -q`
- `python -m py_compile app.py models.py routes.py`

------
https://chatgpt.com/codex/tasks/task_e_6861560192448327842a1548a9a31159