### PR TITLE
Revamp 1‑hour report processing

### DIFF
--- a/logic/one_hour_report.py
+++ b/logic/one_hour_report.py
@@ -3,34 +3,62 @@ import pandas as pd
 
 
 def process_one_hour_report_file(uploaded_file):
-    """Process uploaded CSV file for the 1-hour report.
+    """Process uploaded CSV file for the 1-hour report using the new structure.
 
-    Returns a tuple of (message, table_data, chart_labels, chart_values).
+    Returns a tuple of
+        (message,
+         ready_to_assign,
+         assign_count,
+         transaction_table,
+         chart_labels,
+         chart_values,
+         child_percentage)
     """
     if not uploaded_file or not uploaded_file.filename:
-        return None, None, None, None
+        return None, None, None, None, None, None, None
 
     try:
         df = pd.read_csv(uploaded_file)
-        # Try to find a column named city or country
-        city_col = next((col for col in df.columns if col.lower() in ['city', 'country']), None)
-        if not city_col:
-            return 'No city column found', None, None, None
 
-        counts = df[city_col].value_counts()
-        total = counts.sum()
-        table_data = [
-            {
-                'city': city,
-                'customers': int(count),
-                'percent': count / total * 100,
-            }
-            for city, count in counts.items()
+        # Identify status and transaction columns
+        status_col = next((c for c in df.columns if c.lower() == 'status'), None)
+        transaction_col = next((c for c in df.columns if c.lower() == 'transaction'), None)
+
+        if status_col is None or transaction_col is None:
+            return 'Required columns not found', None, None, None, None, None, None
+
+        # Counts for specific status values
+        status_counts = df[status_col].value_counts()
+        ready_to_assign = int(status_counts.get('Ready to assign', 0) +
+                             status_counts.get('Ready To Assign', 0))
+        assign_count = int(status_counts.get('Assign', 0) +
+                          status_counts.get('Assigned', 0))
+
+        # Counts per transaction
+        transactions = df[transaction_col].value_counts()
+        transaction_table = [
+            {'transaction': t, 'count': int(c)} for t, c in transactions.items()
         ]
-        # Convert numpy types to plain Python objects for JSON encoding
-        chart_labels = json.dumps(counts.index.tolist())
-        chart_values = json.dumps([int(v) for v in counts.values])
+
+        chart_labels = json.dumps(transactions.index.tolist())
+        chart_values = json.dumps([int(v) for v in transactions.values])
+
+        # Percentage of rows representing child tasks
+        child_percentage = None
+        if 'Task' in df.columns:
+            mask = df['Task'].astype(str).str.contains('child', case=False, na=False)
+            child_percentage = (mask.sum() / len(df) * 100) if len(df) else 0.0
+        elif 'No. Of task details' in df.columns:
+            mask = df['No. Of task details'].fillna(0).astype(float) > 0
+            child_percentage = (mask.sum() / len(df) * 100) if len(df) else 0.0
+
         message = f"Processed {uploaded_file.filename}"
-        return message, table_data, chart_labels, chart_values
+        return (message,
+                ready_to_assign,
+                assign_count,
+                transaction_table,
+                chart_labels,
+                chart_values,
+                child_percentage)
     except Exception as exc:
-        return f"Error processing file: {exc}", None, None, None
+        return f"Error processing file: {exc}", None, None, None, None, None, None

--- a/routes.py
+++ b/routes.py
@@ -62,22 +62,31 @@ def dashboard():
 @login_required
 def one_hour_report():
     message = None
-    table_data = None
+    ready_to_assign = None
+    assign_count = None
+    transaction_table = None
     chart_labels = None
     chart_values = None
+    child_percentage = None
     if request.method == 'POST':
         uploaded_file = request.files.get('file')
         (message,
-         table_data,
+         ready_to_assign,
+         assign_count,
+         transaction_table,
          chart_labels,
-         chart_values) = process_one_hour_report_file(uploaded_file)
+         chart_values,
+         child_percentage) = process_one_hour_report_file(uploaded_file)
     return render_template(
         'pages/one_hour_report.html',
         title='1-Hour Report',
         message=message,
-        table_data=table_data,
+        ready_to_assign=ready_to_assign,
+        assign_count=assign_count,
+        transaction_table=transaction_table,
         chart_labels=chart_labels,
         chart_values=chart_values,
+        child_percentage=child_percentage,
     )
 
 @bp.route('/greet/<name>')

--- a/templates/pages/one_hour_report.html
+++ b/templates/pages/one_hour_report.html
@@ -10,32 +10,41 @@
         <button type="submit" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Upload</button>
     </form>
 
-    {% if table_data %}
-    <h2 class="text-xl font-bold mt-4">Customers by City</h2>
+    {% if ready_to_assign is not none %}
+    <h2 class="text-xl font-bold mt-4">Status Counts</h2>
+    <ul class="list-disc pl-5">
+        <li>Ready to Assign: {{ ready_to_assign }}</li>
+        <li>Assign: {{ assign_count }}</li>
+    </ul>
+    {% endif %}
+
+    {% if transaction_table %}
+    <h2 class="text-xl font-bold mt-4">Transactions</h2>
     <table class="min-w-full border-collapse my-4">
         <thead class="bg-gray-200">
             <tr>
-                <th class="border px-4 py-2 text-left">City</th>
-                <th class="border px-4 py-2 text-left">Customers</th>
-                <th class="border px-4 py-2 text-left">Percent</th>
+                <th class="border px-4 py-2 text-left">Transaction</th>
+                <th class="border px-4 py-2 text-left">Count</th>
             </tr>
         </thead>
         <tbody>
-            {% for row in table_data %}
+            {% for row in transaction_table %}
             <tr>
-                <td class="border px-4 py-2">{{ row.city }}</td>
-                <td class="border px-4 py-2">{{ row.customers }}</td>
-                <td class="border px-4 py-2">{{ '%.1f' % row.percent }}%</td>
+                <td class="border px-4 py-2">{{ row.transaction }}</td>
+                <td class="border px-4 py-2">{{ row.count }}</td>
             </tr>
             {% endfor %}
         </tbody>
     </table>
-
     <canvas id="pieChart" class="mx-auto" height="300"
             data-labels="{{ chart_labels|safe }}"
             data-values="{{ chart_values|safe }}"></canvas>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="{{ url_for('static', filename='js/one_hour_report.js') }}"></script>
+    {% endif %}
+
+    {% if child_percentage is not none %}
+    <p class="mt-4">Children Percentage: {{ '%.1f' % child_percentage }}%</p>
     {% endif %}
 </div>
 {% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- rework `process_one_hour_report_file` for the new report layout
- adapt `/1-hour-report` route to supply new fields
- update report template to show status counts, transactions and child task percentage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861afead0e48327bc8361789edb598a