### PR TITLE
Add task detail summary to 1‑hour report

### DIFF
--- a/logic/one_hour_report.py
+++ b/logic/one_hour_report.py
@@ -2,6 +2,16 @@ import json
 import pandas as pd
 
 
+def _find_column(df: pd.DataFrame, candidates):
+    """Return the first matching column name from candidates ignoring case and spaces."""
+    normalized = {c.lower().replace(" ", ""): c for c in df.columns}
+    for candidate in candidates:
+        key = candidate.lower().replace(" ", "")
+        if key in normalized:
+            return normalized[key]
+    return None
+
+
 def process_one_hour_report_file(uploaded_file):
     """Process uploaded CSV file for the 1-hour report using the new structure.
 
@@ -12,7 +22,7 @@ def process_one_hour_report_file(uploaded_file):
          transaction_table,
          chart_labels,
          chart_values,
-         child_percentage)
+         task_detail_summary)
     """
     if not uploaded_file or not uploaded_file.filename:
         return None, None, None, None, None, None, None
@@ -21,35 +31,76 @@ def process_one_hour_report_file(uploaded_file):
         df = pd.read_csv(uploaded_file)
 
         # Identify status and transaction columns
-        status_col = next((c for c in df.columns if c.lower() == 'status'), None)
-        transaction_col = next((c for c in df.columns if c.lower() == 'transaction'), None)
+        status_col = next((c for c in df.columns if c.lower() == "status"), None)
+        transaction_col = next(
+            (c for c in df.columns if c.lower() == "transaction"), None
+        )
 
         if status_col is None or transaction_col is None:
-            return 'Required columns not found', None, None, None, None, None, None
+            return "Required columns not found", None, None, None, None, None, None
 
         # Counts for specific status values
         status_counts = df[status_col].value_counts()
-        ready_to_assign = int(status_counts.get('Ready For Assignment', 0))
-        assign_count = int(status_counts.get('Assigned', 0))
+        ready_to_assign = int(status_counts.get("Ready For Assignment", 0))
+        assign_count = int(status_counts.get("Assigned", 0))
 
         # Counts per transaction
         transactions = df[transaction_col].value_counts()
         transaction_table = [
-            {'transaction': t, 'count': int(c)} for t, c in transactions.items()
+            {"transaction": t, "count": int(c)} for t, c in transactions.items()
         ]
 
         chart_labels = json.dumps(transactions.index.tolist())
         chart_values = json.dumps([int(v) for v in transactions.values])
 
+        # Optional processing for transfer task details
+        task_details_col = _find_column(
+            df,
+            [
+                "No. Of Task Details",
+                "No Of Task Details",
+                "Task Details",
+            ],
+        )
+        transfer_col = (
+            _find_column(
+                df,
+                [
+                    "Transfer Task",
+                    "Transfer",
+                    "Transaction",
+                ],
+            )
+            or transaction_col
+        )
 
+        task_detail_summary = None
+        if task_details_col and transfer_col:
+            grouped = df.groupby(transfer_col)[task_details_col].sum().reset_index()
+            total_details = grouped[task_details_col].sum()
+            task_detail_summary = []
+            for _, row in grouped.iterrows():
+                value = int(row[task_details_col])
+                percent = (
+                    round((value / total_details) * 100, 2) if total_details else 0
+                )
+                task_detail_summary.append(
+                    {
+                        "transfer": row[transfer_col],
+                        "task_details_sum": value,
+                        "percentage": percent,
+                    }
+                )
 
         message = f"Processed {uploaded_file.filename}"
-        return (message,
-                ready_to_assign,
-                assign_count,
-                transaction_table,
-                chart_labels,
-                chart_values,
-                )
+        return (
+            message,
+            ready_to_assign,
+            assign_count,
+            transaction_table,
+            chart_labels,
+            chart_values,
+            task_detail_summary,
+        )
     except Exception as exc:
         return f"Error processing file: {exc}", None, None, None, None, None, None

--- a/routes.py
+++ b/routes.py
@@ -4,61 +4,69 @@ from flask_login import login_user, logout_user, login_required
 from logic.one_hour_report import process_one_hour_report_file
 from models import db, User
 
-bp = Blueprint('main', __name__)
+bp = Blueprint("main", __name__)
 
-@bp.route('/')
+
+@bp.route("/")
 def greeting():
-    return render_template('pages/greeting.html', title='Greeting')
+    return render_template("pages/greeting.html", title="Greeting")
 
-@bp.route('/login', methods=['GET', 'POST'])
+
+@bp.route("/login", methods=["GET", "POST"])
 def login():
     message = None
-    if request.method == 'POST':
-        username = request.form.get('username')
-        password = request.form.get('password')
+    if request.method == "POST":
+        username = request.form.get("username")
+        password = request.form.get("password")
         user = User.query.filter_by(username=username).first()
         if user and user.check_password(password):
             login_user(user)
-            next_url = request.args.get('next') or url_for('main.dashboard')
+            next_url = request.args.get("next") or url_for("main.dashboard")
             return redirect(next_url)
-        message = 'Invalid credentials'
-    return render_template('pages/login.html', title='Login', message=message)
+        message = "Invalid credentials"
+    return render_template("pages/login.html", title="Login", message=message)
 
 
-@bp.route('/logout')
+@bp.route("/logout")
 @login_required
 def logout():
     logout_user()
-    return redirect(url_for('main.login'))
+    return redirect(url_for("main.login"))
 
-@bp.route('/create-user', methods=['GET', 'POST'])
+
+@bp.route("/create-user", methods=["GET", "POST"])
 def create_user():
     message = None
-    if request.method == 'POST' and os.getenv('DEBUG') == 'True':
-        username = request.form.get('username')
-        password = request.form.get('password')
+    if request.method == "POST" and os.getenv("DEBUG") == "True":
+        username = request.form.get("username")
+        password = request.form.get("password")
         if not username or not password:
-            message = 'Username and password are required'
+            message = "Username and password are required"
         elif User.query.filter_by(username=username).first():
-            message = 'User already exists'
+            message = "User already exists"
         else:
             user = User(username=username)
             user.set_password(password)
             db.session.add(user)
             db.session.commit()
-            message = f'Created user {username}'
-    return render_template('pages/create_user.html', title='Create User', message=message)
+            message = f"Created user {username}"
+    return render_template(
+        "pages/create_user.html", title="Create User", message=message
+    )
 
-@bp.route('/home')
+
+@bp.route("/home")
 def home():
-    return render_template('pages/home.html', title='Home')
+    return render_template("pages/home.html", title="Home")
 
-@bp.route('/dashboard')
+
+@bp.route("/dashboard")
 @login_required
 def dashboard():
-    return render_template('pages/dashboard.html', title='Dashboard')
+    return render_template("pages/dashboard.html", title="Dashboard")
 
-@bp.route('/1-hour-report', methods=['GET', 'POST'])
+
+@bp.route("/1-hour-report", methods=["GET", "POST"])
 @login_required
 def one_hour_report():
     message = None
@@ -67,31 +75,38 @@ def one_hour_report():
     transaction_table = None
     chart_labels = None
     chart_values = None
-    if request.method == 'POST':
-        uploaded_file = request.files.get('file')
-        (message,
-         ready_to_assign,
-         assign_count,
-         transaction_table,
-         chart_labels,
-         chart_values,) = process_one_hour_report_file(uploaded_file)
+    task_detail_summary = None
+    if request.method == "POST":
+        uploaded_file = request.files.get("file")
+        (
+            message,
+            ready_to_assign,
+            assign_count,
+            transaction_table,
+            chart_labels,
+            chart_values,
+            task_detail_summary,
+        ) = process_one_hour_report_file(uploaded_file)
     return render_template(
-        'pages/one_hour_report.html',
-        title='1-Hour Report',
+        "pages/one_hour_report.html",
+        title="1-Hour Report",
         message=message,
         ready_to_assign=ready_to_assign,
         assign_count=assign_count,
         transaction_table=transaction_table,
         chart_labels=chart_labels,
         chart_values=chart_values,
+        task_detail_summary=task_detail_summary,
     )
 
-@bp.route('/greet/<name>')
+
+@bp.route("/greet/<name>")
 def greet(name):
     return f"<p>Hello, {name}!</p>"
 
-@bp.route('/handle_url_params')
+
+@bp.route("/handle_url_params")
 def handle_url_params():
-    greeting = request.args.get('greeting', 'default_value1')
-    name = request.args.get('name', 'default_value2')
+    greeting = request.args.get("greeting", "default_value1")
+    name = request.args.get("name", "default_value2")
     return f"<h2>greeting: {greeting}, name: {name}</h2>"

--- a/templates/pages/one_hour_report.html
+++ b/templates/pages/one_hour_report.html
@@ -43,6 +43,28 @@
     <script src="{{ url_for('static', filename='js/one_hour_report.js') }}"></script>
     {% endif %}
 
+    {% if task_detail_summary %}
+    <h2 class="text-xl font-bold mt-4">Task Details by Transfer</h2>
+    <table class="min-w-full border-collapse my-4">
+        <thead class="bg-gray-200">
+            <tr>
+                <th class="border px-4 py-2 text-left">Transfer</th>
+                <th class="border px-4 py-2 text-left">Sum of Task Details</th>
+                <th class="border px-4 py-2 text-left">% of Total</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in task_detail_summary %}
+            <tr>
+                <td class="border px-4 py-2">{{ row.transfer }}</td>
+                <td class="border px-4 py-2">{{ row.task_details_sum }}</td>
+                <td class="border px-4 py-2">{{ row.percentage }}%</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
+
 
 </div>
 {% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- add helper for locating columns in uploaded CSV
- compute sum of `No. Of Task Details` per transfer
- expose the new summary via route and template

## Testing
- `python -m py_compile logic/one_hour_report.py routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861cb54e9a8832783b99c11d46d3aae