### PR TITLE
Simplify 1-hour report

### DIFF
--- a/logic/one_hour_report.py
+++ b/logic/one_hour_report.py
@@ -1,106 +1,25 @@
-import json
 import pandas as pd
 
 
-def _find_column(df: pd.DataFrame, candidates):
-    """Return the first matching column name from candidates ignoring case and spaces."""
-    normalized = {c.lower().replace(" ", ""): c for c in df.columns}
-    for candidate in candidates:
-        key = candidate.lower().replace(" ", "")
-        if key in normalized:
-            return normalized[key]
-    return None
+def count_assigned_tasks(uploaded_file):
+    """Return a tuple of message and number of assigned tasks.
 
-
-def process_one_hour_report_file(uploaded_file):
-    """Process uploaded CSV file for the 1-hour report using the new structure.
-
-    Returns a tuple of
-        (message,
-         ready_to_assign,
-         assign_count,
-         transaction_table,
-         chart_labels,
-         chart_values,
-         task_detail_summary)
+    The CSV file must contain a column named "Call Status" (case-insensitive).
     """
     if not uploaded_file or not uploaded_file.filename:
-        return None, None, None, None, None, None, None
+        return None, None
 
     try:
         df = pd.read_csv(uploaded_file)
-
-        # Identify status and transaction columns
-        status_col = next((c for c in df.columns if c.lower() == "status"), None)
-        transaction_col = next(
-            (c for c in df.columns if c.lower() == "transaction"), None
+        status_col = next(
+            (c for c in df.columns if c.lower().replace(" ", "") == "callstatus"),
+            None,
         )
+        if status_col is None:
+            return "Required column 'Call Status' not found", None
 
-        if status_col is None or transaction_col is None:
-            return "Required columns not found", None, None, None, None, None, None
-
-        # Counts for specific status values
-        status_counts = df[status_col].value_counts()
-        ready_to_assign = int(status_counts.get("Ready For Assignment", 0))
-        assign_count = int(status_counts.get("Assigned", 0))
-
-        # Counts per transaction
-        transactions = df[transaction_col].value_counts()
-        transaction_table = [
-            {"transaction": t, "count": int(c)} for t, c in transactions.items()
-        ]
-
-        chart_labels = json.dumps(transactions.index.tolist())
-        chart_values = json.dumps([int(v) for v in transactions.values])
-
-        # Optional processing for transfer task details
-        task_details_col = _find_column(
-            df,
-            [
-                "No. Of Task Details",
-                "No Of Task Details",
-                "Task Details",
-            ],
-        )
-        transfer_col = (
-            _find_column(
-                df,
-                [
-                    "Transfer Task",
-                    "Transfer",
-                    "Transaction",
-                ],
-            )
-            or transaction_col
-        )
-
-        task_detail_summary = None
-        if task_details_col and transfer_col:
-            grouped = df.groupby(transfer_col)[task_details_col].sum().reset_index()
-            total_details = grouped[task_details_col].sum()
-            task_detail_summary = []
-            for _, row in grouped.iterrows():
-                value = int(row[task_details_col])
-                percent = (
-                    round((value / total_details) * 100, 2) if total_details else 0
-                )
-                task_detail_summary.append(
-                    {
-                        "transfer": row[transfer_col],
-                        "task_details_sum": value,
-                        "percentage": percent,
-                    }
-                )
-
+        assigned_count = int((df[status_col].astype(str).str.lower() == "assigned").sum())
         message = f"Processed {uploaded_file.filename}"
-        return (
-            message,
-            ready_to_assign,
-            assign_count,
-            transaction_table,
-            chart_labels,
-            chart_values,
-            task_detail_summary,
-        )
+        return message, assigned_count
     except Exception as exc:
-        return f"Error processing file: {exc}", None, None, None, None, None, None
+        return f"Error processing file: {exc}", None

--- a/routes.py
+++ b/routes.py
@@ -1,7 +1,7 @@
 import os
 from flask import Blueprint, render_template, request, redirect, url_for
 from flask_login import login_user, logout_user, login_required
-from logic.one_hour_report import process_one_hour_report_file
+from logic.one_hour_report import count_assigned_tasks
 from models import db, User
 
 bp = Blueprint("main", __name__)
@@ -70,33 +70,15 @@ def dashboard():
 @login_required
 def one_hour_report():
     message = None
-    ready_to_assign = None
     assign_count = None
-    transaction_table = None
-    chart_labels = None
-    chart_values = None
-    task_detail_summary = None
     if request.method == "POST":
         uploaded_file = request.files.get("file")
-        (
-            message,
-            ready_to_assign,
-            assign_count,
-            transaction_table,
-            chart_labels,
-            chart_values,
-            task_detail_summary,
-        ) = process_one_hour_report_file(uploaded_file)
+        message, assign_count = count_assigned_tasks(uploaded_file)
     return render_template(
         "pages/one_hour_report.html",
         title="1-Hour Report",
         message=message,
-        ready_to_assign=ready_to_assign,
         assign_count=assign_count,
-        transaction_table=transaction_table,
-        chart_labels=chart_labels,
-        chart_values=chart_values,
-        task_detail_summary=task_detail_summary,
     )
 
 

--- a/templates/pages/one_hour_report.html
+++ b/templates/pages/one_hour_report.html
@@ -10,61 +10,9 @@
         <button type="submit" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Upload</button>
     </form>
 
-    {% if ready_to_assign is not none %}
-    <h2 class="text-xl font-bold mt-4">Status Counts</h2>
-    <ul class="list-disc pl-5">
-        <li>Ready to Assign: {{ ready_to_assign }}</li>
-        <li>Assign: {{ assign_count }}</li>
-    </ul>
+    {% if assign_count is not none %}
+    <h2 class="text-xl font-bold mt-4">Assigned Tasks</h2>
+    <p>{{ assign_count }}</p>
     {% endif %}
-
-    {% if transaction_table %}
-    <h2 class="text-xl font-bold mt-4">Transactions</h2>
-    <table class="min-w-full border-collapse my-4">
-        <thead class="bg-gray-200">
-            <tr>
-                <th class="border px-4 py-2 text-left">Transaction</th>
-                <th class="border px-4 py-2 text-left">Count</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for row in transaction_table %}
-            <tr>
-                <td class="border px-4 py-2">{{ row.transaction }}</td>
-                <td class="border px-4 py-2">{{ row.count }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-    <canvas id="pieChart" class="mx-auto" height="300"
-            data-labels="{{ chart_labels|safe }}"
-            data-values="{{ chart_values|safe }}"></canvas>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="{{ url_for('static', filename='js/one_hour_report.js') }}"></script>
-    {% endif %}
-
-    {% if task_detail_summary %}
-    <h2 class="text-xl font-bold mt-4">Task Details by Transfer</h2>
-    <table class="min-w-full border-collapse my-4">
-        <thead class="bg-gray-200">
-            <tr>
-                <th class="border px-4 py-2 text-left">Transfer</th>
-                <th class="border px-4 py-2 text-left">Sum of Task Details</th>
-                <th class="border px-4 py-2 text-left">% of Total</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for row in task_detail_summary %}
-            <tr>
-                <td class="border px-4 py-2">{{ row.transfer }}</td>
-                <td class="border px-4 py-2">{{ row.task_details_sum }}</td>
-                <td class="border px-4 py-2">{{ row.percentage }}%</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-    {% endif %}
-
-
 </div>
 {% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- remove original 1-hour report logic
- add a minimal function that only counts `Assigned` tasks from column `Call Status`
- update the `/1-hour-report` route to use the new function
- simplify the 1-Hour Report page to just display the assigned task count

## Testing
- `python -m py_compile routes.py logic/one_hour_report.py`

------
https://chatgpt.com/codex/tasks/task_e_6861d0eb62208327ad028543b2b6fc1d