### PR TITLE
Add transaction summary to 1-hour report

### DIFF
--- a/logic/one_hour_report.py
+++ b/logic/one_hour_report.py
@@ -2,12 +2,17 @@ import pandas as pd
 
 
 def count_assigned_tasks(uploaded_file):
-    """Return a tuple of message and number of assigned tasks.
+    """Process a 1‑Hour Report CSV file.
 
-    The CSV file must contain a column named "Call Status" (case-insensitive).
+    Returns a tuple ``(message, assigned_count, ready_for_assignment,
+    transaction_summary)`` where ``transaction_summary`` is a list of
+    dictionaries with ``transaction`` and ``task_details`` keys.  The
+    CSV file must include a ``Status`` column and, for the summary, both
+    ``Transaction`` and ``No. Of task details`` columns (case-insensitive).
     """
+
     if not uploaded_file or not uploaded_file.filename:
-        return None, None
+        return None, None, None, None
 
     try:
         df = pd.read_csv(uploaded_file)
@@ -16,11 +21,35 @@ def count_assigned_tasks(uploaded_file):
             None,
         )
         if status_col is None:
-            return "Required column 'Call Status' not found", None
+            return "Required column 'Call Status' not found", None, None, None
 
         assigned_count = int((df[status_col].astype(str).str.lower() == "assigned").sum())
         ready_for_assignment = int((df[status_col].astype(str).str.lower() == "ready for assignment").sum())
+
+        trans_col = next(
+            (c for c in df.columns if c.lower().replace(" ", "") == "transaction"),
+            None,
+        )
+        task_details_col = next(
+            (
+                c
+                for c in df.columns
+                if c.lower().replace(" ", "") in ["no.oftaskdetails", "nooftaskdetails"]
+            ),
+            None,
+        )
+
+        transaction_summary = None
+        if trans_col and task_details_col:
+            summary_df = (
+                df.groupby(trans_col)[task_details_col]
+                .sum()
+                .reset_index()
+                .rename(columns={trans_col: "transaction", task_details_col: "task_details"})
+            )
+            transaction_summary = summary_df.to_dict(orient="records")
+
         message = f"Processed {uploaded_file.filename}"
-        return message, assigned_count , ready_for_assignment
+        return message, assigned_count, ready_for_assignment, transaction_summary
     except Exception as exc:
-        return f"Error processing file: {exc}", None
+        return f"Error processing file: {exc}", None, None, None

--- a/routes.py
+++ b/routes.py
@@ -72,15 +72,22 @@ def one_hour_report():
     message = None
     assign_count = None
     ready_for_assignment = None
+    transaction_summary = None
     if request.method == "POST":
         uploaded_file = request.files.get("file")
-        message, assign_count,ready_for_assignment = count_assigned_tasks(uploaded_file)
+        (
+            message,
+            assign_count,
+            ready_for_assignment,
+            transaction_summary,
+        ) = count_assigned_tasks(uploaded_file)
     return render_template(
         "pages/one_hour_report.html",
         title="1-Hour Report",
         message=message,
         assign_count=assign_count,
         ready_for_assignment=ready_for_assignment,
+        transaction_summary=transaction_summary,
     )
 
 

--- a/templates/pages/one_hour_report.html
+++ b/templates/pages/one_hour_report.html
@@ -19,5 +19,25 @@
     <h2 class="text-xl font-bold mt-4">Ready For Assignment</h2>
     <p>{{ ready_for_assignment }}</p>
     {% endif %}
+
+    {% if transaction_summary %}
+    <h2 class="text-xl font-bold mt-4">Tasks Per Transaction</h2>
+    <table class="table-auto border-collapse mt-2">
+        <thead>
+            <tr>
+                <th class="border px-4 py-2">Transaction</th>
+                <th class="border px-4 py-2">No. Of task details</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in transaction_summary %}
+            <tr>
+                <td class="border px-4 py-2">{{ row.transaction }}</td>
+                <td class="border px-4 py-2 text-right">{{ row.task_details }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
 </div>
 {% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- extend `count_assigned_tasks` to also summarize `No. Of task details` by transaction
- display the new summary table in 1‑Hour Report page
- show summary in `/1-hour-report` route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d959ed588327a2e38a24c2cae768