### PR TITLE
Add percentage per transaction

### DIFF
--- a/templates/pages/one_hour_report.html
+++ b/templates/pages/one_hour_report.html
@@ -27,6 +27,7 @@
             <tr>
                 <th class="border px-4 py-2">Transaction</th>
                 <th class="border px-4 py-2">No. Of task details</th>
+                <th class="border px-4 py-2">Percentage</th>
             </tr>
         </thead>
         <tbody>
@@ -34,6 +35,7 @@
             <tr>
                 <td class="border px-4 py-2">{{ row.transaction }}</td>
                 <td class="border px-4 py-2 text-right">{{ row.task_details }}</td>
+                <td class="border px-4 py-2 text-right">{{ row.percentage }}%</td>
             </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- compute percent of tasks per transaction
- display percentage and totals in the transaction summary table

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861db32b80083279fb7a3a4b70946b0