### PR TITLE
Add assigned tasks table to report

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ the **Create User** page and then sign in using the login form.  Once
 authenticated the **Dashboard** and **1‑Hour Report** pages become available.
 Logging out clears the session and redirects back to the login page.
 
+The **1‑Hour Report** page now also shows a table containing only rows where the
+``Status`` column value is ``Assigned`` when a CSV file is uploaded.
+
 ## Template structure
 
 HTML templates are organized under `templates/`:

--- a/routes.py
+++ b/routes.py
@@ -73,6 +73,7 @@ def one_hour_report():
     assign_count = None
     ready_for_assignment = None
     transaction_summary = None
+    assigned_html = None
     if request.method == "POST":
         uploaded_file = request.files.get("file")
         (
@@ -80,7 +81,13 @@ def one_hour_report():
             assign_count,
             ready_for_assignment,
             transaction_summary,
+            assigned_df,
         ) = count_assigned_tasks(uploaded_file)
+
+        assigned_html = assigned_df.to_html(
+            classes="table-auto border-collapse mt-2",
+            index=False,
+        )
     return render_template(
         "pages/one_hour_report.html",
         title="1-Hour Report",
@@ -88,6 +95,7 @@ def one_hour_report():
         assign_count=assign_count,
         ready_for_assignment=ready_for_assignment,
         transaction_summary=transaction_summary,
+        assigned_table=assigned_html,
     )
 
 

--- a/templates/pages/one_hour_report.html
+++ b/templates/pages/one_hour_report.html
@@ -41,5 +41,10 @@
         </tbody>
     </table>
     {% endif %}
+
+    {% if assigned_table %}
+    <h2 class="text-xl font-bold mt-4">Assigned Status Rows</h2>
+    {{ assigned_table | safe }}
+    {% endif %}
 </div>
 {% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- enhance report logic to return DataFrame of assigned rows
- render assigned rows table in the 1-Hour Report page
- document the new feature

## Testing
- `pytest -q`
- `python -m py_compile app.py routes.py logic/one_hour_report.py`

------
https://chatgpt.com/codex/tasks/task_e_6861dea86da48327b361fd7f259a3670