### PR TITLE
Add assigned transaction summary table

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ the **Create User** page and then sign in using the login form.  Once
 authenticated the **Dashboard** and **1‑Hour Report** pages become available.
 Logging out clears the session and redirects back to the login page.
 
-The **1‑Hour Report** page now also shows a table containing only rows where the
-``Status`` column value is ``Assigned`` when a CSV file is uploaded.
+The **1‑Hour Report** page now displays two summary tables when a CSV file is
+uploaded.  The first table, **Tasks Per Transaction**, uses all rows in the
+file.  A second table, **Assigned Status Tasks Per Transaction**, summarises
+only those rows where the ``Status`` column value is ``Assigned``.
 
 ## Template structure
 

--- a/app.py
+++ b/app.py
@@ -24,4 +24,8 @@ def create_app():
 
 if __name__ == "__main__":
     app = create_app()
-    app.run(debug=os.getenv("DEBUG"), host=os.getenv('HOST'), port=os.getenv('PORT', 5000))
+    app.run(
+        debug=os.getenv("DEBUG"),
+        host=os.getenv("HOST"),
+        port=os.getenv("PORT", 5000),
+    )

--- a/logic/one_hour_report.py
+++ b/logic/one_hour_report.py
@@ -5,12 +5,13 @@ def count_assigned_tasks(uploaded_file):
     """Process a 1‑Hour Report CSV file.
 
     Returns a tuple ``(message, assigned_count, ready_for_assignment,
-    transaction_summary, assigned_df)`` where ``transaction_summary`` is a list
-    of dictionaries with ``transaction``, ``task_details`` and ``percentage``
-    keys.  ``assigned_df`` is a pandas ``DataFrame`` containing only rows where
-    the ``Status`` column has the value ``Assigned``.  The CSV file must include
-    a ``Status`` column and, for the summary, both ``Transaction`` and ``No. Of
-    task details`` columns (case-insensitive).
+    transaction_summary, assigned_transaction_summary)`` where both summary
+    values are lists of dictionaries with ``transaction``, ``task_details`` and
+    ``percentage`` keys. ``transaction_summary`` is calculated using **all**
+    rows in the CSV file while ``assigned_transaction_summary`` only includes
+    rows where the ``Status`` column is ``Assigned``. The CSV file must include
+    a ``Status`` column and, for the summaries, both ``Transaction`` and
+    ``No. Of task details`` columns (case-insensitive).
     """
 
     if not uploaded_file or not uploaded_file.filename:
@@ -23,27 +24,44 @@ def count_assigned_tasks(uploaded_file):
             None,
         )
         if status_col is None:
-            return "Required column 'Call Status' not found", None, None, None, None
+            return (
+                "Required column 'Call Status' not found",
+                None,
+                None,
+                None,
+                None,
+            )
 
         assigned_mask = df[status_col].astype(str).str.lower() == "assigned"
         assigned_count = int(assigned_mask.sum())
-        ready_for_assignment = int((df[status_col].astype(str).str.lower() == "ready for assignment").sum())
+        ready_for_assignment = int(
+            (
+                df[status_col].astype(str).str.lower()
+                == "ready for assignment"
+            ).sum()
+        )
         assigned_df = df[assigned_mask].copy()
 
         trans_col = next(
-            (c for c in df.columns if c.lower().replace(" ", "") == "transaction"),
+            (
+                c
+                for c in df.columns
+                if c.lower().replace(" ", "") == "transaction"
+            ),
             None,
         )
         task_details_col = next(
             (
                 c
                 for c in df.columns
-                if c.lower().replace(" ", "") in ["no.oftaskdetails", "nooftaskdetails"]
+                if c.lower().replace(" ", "")
+                in ["no.oftaskdetails", "nooftaskdetails"]
             ),
             None,
         )
 
         transaction_summary = None
+        assigned_transaction_summary = None
         if trans_col and task_details_col:
             summary_df = (
                 df.groupby(trans_col)[task_details_col]
@@ -71,13 +89,43 @@ def count_assigned_tasks(uploaded_file):
                 }
             )
 
+            assigned_summary_df = (
+                assigned_df.groupby(trans_col)[task_details_col]
+                .sum()
+                .reset_index()
+                .rename(
+                    columns={
+                        trans_col: "transaction",
+                        task_details_col: "task_details",
+                    }
+                )
+            )
+            assigned_summary_df["task_details"] = assigned_summary_df[
+                "task_details"
+            ].astype(int)
+            assigned_total = assigned_summary_df["task_details"].sum()
+            assigned_summary_df["percentage"] = (
+                assigned_summary_df["task_details"] / assigned_total * 100
+            ).round(2)
+
+            assigned_transaction_summary = assigned_summary_df.to_dict(
+                orient="records"
+            )
+            assigned_transaction_summary.append(
+                {
+                    "transaction": "Total",
+                    "task_details": int(assigned_total),
+                    "percentage": 100.0,
+                }
+            )
+
         message = f"Processed {uploaded_file.filename}"
         return (
             message,
             assigned_count,
             ready_for_assignment,
             transaction_summary,
-            assigned_df,
+            assigned_transaction_summary,
         )
     except Exception as exc:
         return f"Error processing file: {exc}", None, None, None, None

--- a/routes.py
+++ b/routes.py
@@ -73,7 +73,7 @@ def one_hour_report():
     assign_count = None
     ready_for_assignment = None
     transaction_summary = None
-    assigned_html = None
+    assigned_transaction_summary = None
     if request.method == "POST":
         uploaded_file = request.files.get("file")
         (
@@ -81,13 +81,8 @@ def one_hour_report():
             assign_count,
             ready_for_assignment,
             transaction_summary,
-            assigned_df,
+            assigned_transaction_summary,
         ) = count_assigned_tasks(uploaded_file)
-
-        assigned_html = assigned_df.to_html(
-            classes="table-auto border-collapse mt-2",
-            index=False,
-        )
     return render_template(
         "pages/one_hour_report.html",
         title="1-Hour Report",
@@ -95,7 +90,7 @@ def one_hour_report():
         assign_count=assign_count,
         ready_for_assignment=ready_for_assignment,
         transaction_summary=transaction_summary,
-        assigned_table=assigned_html,
+        assigned_summary=assigned_transaction_summary,
     )
 
 

--- a/templates/pages/one_hour_report.html
+++ b/templates/pages/one_hour_report.html
@@ -42,9 +42,26 @@
     </table>
     {% endif %}
 
-    {% if assigned_table %}
-    <h2 class="text-xl font-bold mt-4">Assigned Status Rows</h2>
-    {{ assigned_table | safe }}
+    {% if assigned_summary %}
+    <h2 class="text-xl font-bold mt-4">Assigned Status Tasks Per Transaction</h2>
+    <table class="table-auto border-collapse mt-2">
+        <thead>
+            <tr>
+                <th class="border px-4 py-2">Transaction</th>
+                <th class="border px-4 py-2">No. Of task details</th>
+                <th class="border px-4 py-2">Percentage</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in assigned_summary %}
+            <tr>
+                <td class="border px-4 py-2">{{ row.transaction }}</td>
+                <td class="border px-4 py-2 text-right">{{ row.task_details }}</td>
+                <td class="border px-4 py-2 text-right">{{ row.percentage }}%</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
     {% endif %}
 </div>
 {% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- compute task summary for assigned rows only
- remove row table from the 1‑Hour Report page
- show assigned summary table in template
- update README
- tidy `app.run` call and pass new summary through the route

## Testing
- `flake8`
- `python -m py_compile app.py routes.py logic/one_hour_report.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_6861e17a0f6883279dc3945870b9fd8f