### PR TITLE
Add color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ templates/
     pages/      # individual page templates
     elements/   # reusable elements such as header and footer
 ```
+
+## Styling
+
+The application includes a small custom CSS file under `static/styles/`. A color palette is defined in `static/styles/color-palette.css` using CSS variables. Import this file in your styles to access consistent colors across the UI.

--- a/static/styles/color-palette.css
+++ b/static/styles/color-palette.css
@@ -1,0 +1,10 @@
+:root {
+    --color-primary: #3B82F6; /* Blue - calm, reliable */
+    --color-secondary: #6366F1; /* Indigo - modern accent */
+    --color-success: #10B981; /* Green - successful upload */
+    --color-warning: #F59E0B; /* Yellow/Orange - warnings */
+    --color-error: #EF4444; /* Red - errors, failed rows */
+    --color-background: #F9FAFB; /* Light gray - neutral bg */
+    --color-text: #111827; /* Almost black - high contrast */
+    --color-muted-text: #6B7280; /* Gray for less emphasis */
+}

--- a/static/styles/custom.css
+++ b/static/styles/custom.css
@@ -1,3 +1,4 @@
+@import url("color-palette.css");
 body {
     font-family: sans-serif;
 }


### PR DESCRIPTION
## Summary
- create a color palette using CSS variables
- import the palette in `custom.css`
- document the palette location in README

## Testing
- `python -m py_compile app.py models.py routes.py logic/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6861e59a1e1c8327a915f728e8693823