### PR TITLE
Update assigned tasks summary to use counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ authenticated the **Dashboard** and **1‑Hour Report** pages become available.
 Logging out clears the session and redirects back to the login page.
 
 The **1‑Hour Report** page now displays two summary tables when a CSV file is
-uploaded.  The first table, **Tasks Per Transaction**, uses all rows in the
-file.  A second table, **Assigned Status Tasks Per Transaction**, summarises
-only those rows where the ``Status`` column value is ``Assigned``.
+uploaded.  The first table, **Tasks Per Transaction**, sums the ``No. Of task
+details`` column for all rows.  A second table, **Assigned Status Tasks Per
+Transaction**, summarises only those rows where the ``Status`` column value is
+``Assigned`` and shows the count of transactions per type.
 
 ## Template structure
 

--- a/templates/pages/one_hour_report.html
+++ b/templates/pages/one_hour_report.html
@@ -26,7 +26,7 @@
         <thead>
             <tr>
                 <th class="border px-4 py-2">Transaction</th>
-                <th class="border px-4 py-2">No. Of task details</th>
+                <th class="border px-4 py-2">Count</th>
                 <th class="border px-4 py-2">Percentage</th>
             </tr>
         </thead>
@@ -34,7 +34,7 @@
             {% for row in assigned_summary %}
             <tr>
                 <td class="border px-4 py-2">{{ row.transaction }}</td>
-                <td class="border px-4 py-2 text-right">{{ row.task_details }}</td>
+                <td class="border px-4 py-2 text-right">{{ row.count }}</td>
                 <td class="border px-4 py-2 text-right">{{ row.percentage }}%</td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
## Summary
- clarify README about 1‑Hour Report summaries
- count rows per transaction for the assigned status table
- adjust template column heading and value

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863d105419c8327aaa0a21e6a049d23