### PR TITLE
Reintroduce CSV upload for FedEx tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ The application includes a small custom CSS file under `static/styles/`. A color
 
 ## Shipment Tracking
 
-Authenticated users can enter a single FedEx tracking number on the **Track Shipments** page. The application retrieves the status from the FedEx Track API and displays it in a table.
+Authenticated users can upload a CSV file containing FedEx tracking numbers on the **Track Shipments** page. The application reads the "Tracking Number" column, fetches the status for each number from the FedEx Track API, and shows the same table with a new "Status" column.
 
 ### FedEx API configuration
 
 1. Sign up at the [FedEx Developer Portal](https://developer.fedex.com/) and create an application.
 2. Enable the *Track* service for the app and note the provided **Client ID** and **Client Secret**.
 3. Set environment variables `FEDEX_CLIENT_ID` and `FEDEX_CLIENT_SECRET` with these credentials before running the application.
-4. When a tracking number is submitted, the app obtains an OAuth token and calls `https://apis.fedex.com/track/v1/trackingnumbers` to fetch its status.
+4. When a file is uploaded, the app obtains an OAuth token and calls `https://apis.fedex.com/track/v1/trackingnumbers` to fetch statuses.

--- a/logic/tracking_status.py
+++ b/logic/tracking_status.py
@@ -60,20 +60,24 @@ def fetch_tracking_statuses(tracking_numbers):
 
 
 def process_tracking_csv(uploaded_file):
-    """Parse uploaded CSV and return message and tracking statuses."""
+    """Parse uploaded CSV and return message and table rows with statuses."""
     if not uploaded_file or not uploaded_file.filename:
         return "No file uploaded", None
     try:
         df = pd.read_csv(uploaded_file)
         track_col = next(
-            (c for c in df.columns if c.lower().replace(" ", "") in ["tracking", "trackingnumber", "trackingno", "tracking#", "trackingnum"]),
+            (c for c in df.columns if c.strip().lower() == "tracking number"),
             None,
         )
-        if not track_col:
-            return "Tracking number column not found", None
+        if track_col is None:
+            return "Column 'Tracking Number' not found", None
+
         tracking_numbers = df[track_col].astype(str).tolist()
         statuses = fetch_tracking_statuses(tracking_numbers)
-        return f"Processed {uploaded_file.filename}", statuses
+        status_map = {item["tracking_number"]: item["status"] for item in statuses}
+        df["Status"] = df[track_col].astype(str).map(status_map).fillna("Unknown")
+
+        return f"Processed {uploaded_file.filename}", df.to_dict(orient="records")
     except FedExAPIError as exc:
         return str(exc), None
     except Exception as exc:

--- a/routes.py
+++ b/routes.py
@@ -2,7 +2,7 @@ import os
 from flask import Blueprint, render_template, request, redirect, url_for
 from flask_login import login_user, logout_user, login_required
 from logic.one_hour_report import count_assigned_tasks
-from logic.tracking_status import process_single_tracking_number
+from logic.tracking_status import process_tracking_csv
 from models import db, User
 
 bp = Blueprint("main", __name__)
@@ -99,21 +99,16 @@ def one_hour_report():
 @login_required
 def track_shipments():
     message = None
-    error = None
-    status = None
-    tracking_number = None
+    rows = None
     if request.method == "POST":
-        tracking_number = request.form.get("tracking_number")
-        message, status = process_single_tracking_number(tracking_number)
-        if not status:
-            error = message
+        uploaded_file = request.files.get("file")
+        message, rows = process_tracking_csv(uploaded_file)
     return render_template(
         "pages/track_shipments.html",
         title="Shipment Tracking",
-        message=message if status else None,
-        error=error,
-        tracking_number=tracking_number,
-        status=status,
+        message=message if rows else None,
+        error=None if rows else message,
+        rows=rows,
     )
 
 

--- a/templates/pages/track_shipments.html
+++ b/templates/pages/track_shipments.html
@@ -7,26 +7,30 @@
     {% if error and not message %}
     <p class="mb-4 text-red-600">{{ error }}</p>
     {% endif %}
-    <form method="post" class="mb-6">
-        <label for="tracking_number" class="block mb-2 font-medium">Enter Tracking Number</label>
-        <input id="tracking_number" name="tracking_number" type="text" class="border p-2 rounded w-full" />
-        <button type="submit" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Track</button>
+    <form method="post" enctype="multipart/form-data" class="mb-6">
+        <label for="file" class="block mb-2 font-medium">Upload CSV</label>
+        <input id="file" name="file" type="file" class="border p-2 rounded w-full" />
+        <button type="submit" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Upload</button>
     </form>
 
-    {% if status %}
-    <h2 class="text-xl font-bold mt-4">Tracking Status</h2>
+    {% if rows %}
+    <h2 class="text-xl font-bold mt-4">Tracking Statuses</h2>
     <table class="table-auto border-collapse mt-2 palette-table">
         <thead>
             <tr>
-                <th class="border px-4 py-2">Tracking Number</th>
-                <th class="border px-4 py-2">Status</th>
+                {% for col in rows[0].keys() %}
+                <th class="border px-4 py-2">{{ col }}</th>
+                {% endfor %}
             </tr>
         </thead>
         <tbody>
+            {% for row in rows %}
             <tr>
-                <td class="border px-4 py-2">{{ tracking_number }}</td>
-                <td class="border px-4 py-2">{{ status.status }}</td>
+                {% for col in row.keys() %}
+                <td class="border px-4 py-2">{{ row[col] }}</td>
+                {% endfor %}
             </tr>
+            {% endfor %}
         </tbody>
     </table>
     {% endif %}


### PR DESCRIPTION
## Summary
- restore CSV upload form for shipment tracking
- accept column `Tracking Number` and append status column
- update README to reflect CSV workflow

## Testing
- `python -m py_compile app.py routes.py models.py logic/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6865cb3c6ca483278e3f54afedb03b3f