### PR TITLE
Batch FedEx tracking API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ The application includes a small custom CSS file under `static/styles/`. A color
 
 ## Shipment Tracking
 
-Authenticated users can enter a single FedEx tracking number on the **Track Shipments** page. The application retrieves the status from the FedEx Track API and displays it in a table.
+Authenticated users can upload a CSV file containing FedEx tracking numbers on the **Track Shipments** page. The application reads the "Tracking Number" column, fetches the status for each number from the FedEx Track API, and displays a simple table with only two columns: the tracking number and its status.
 
 ### FedEx API configuration
 
 1. Sign up at the [FedEx Developer Portal](https://developer.fedex.com/) and create an application.
 2. Enable the *Track* service for the app and note the provided **Client ID** and **Client Secret**.
 3. Set environment variables `FEDEX_CLIENT_ID` and `FEDEX_CLIENT_SECRET` with these credentials before running the application.
-4. When a tracking number is submitted, the app obtains an OAuth token and calls `https://apis.fedex.com/track/v1/trackingnumbers` to fetch its status.
+4. When a file is uploaded, the app obtains an OAuth token and calls `https://apis.fedex.com/track/v1/trackingnumbers` to fetch statuses.
+5. The API accepts at most 30 tracking numbers per request. DataWasher automatically splits larger uploads into batches of 30.

--- a/logic/tracking_status.py
+++ b/logic/tracking_status.py
@@ -38,42 +38,58 @@ def fetch_tracking_statuses(tracking_numbers):
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
     }
-    body = {
-        "trackingInfo": [
-            {"trackingNumberInfo": {"trackingNumber": num}}
-            for num in tracking_numbers
-        ]
-    }
-    resp = requests.post(FEDEX_TRACK_URL, json=body, headers=headers, timeout=10)
-    if resp.status_code != 200:
-        raise FedExAPIError(f"Track request failed: {resp.status_code} {resp.text}")
 
     statuses = []
-    data = resp.json()
-    results = data.get("output", {}).get("completeTrackResults", [])
-    for item in results:
-        track_data = item.get("trackResults", [{}])[0]
-        num = track_data.get("trackingNumber")
-        status = track_data.get("latestStatusDetail", {}).get("statusByLocale", "Unknown")
-        statuses.append({"tracking_number": num, "status": status})
+    for start in range(0, len(tracking_numbers), 30):
+        batch = tracking_numbers[start : start + 30]
+        body = {
+            "trackingInfo": [
+                {"trackingNumberInfo": {"trackingNumber": num}}
+                for num in batch
+            ]
+        }
+        resp = requests.post(
+            FEDEX_TRACK_URL, json=body, headers=headers, timeout=10
+        )
+        if resp.status_code != 200:
+            raise FedExAPIError(
+                f"Track request failed: {resp.status_code} {resp.text}"
+            )
+
+        data = resp.json()
+        results = data.get("output", {}).get("completeTrackResults", [])
+        for item in results:
+            track_data = item.get("trackResults", [{}])[0]
+            num = track_data.get("trackingNumber")
+            status = (
+                track_data.get("latestStatusDetail", {}).get("statusByLocale", "Unknown")
+            )
+            statuses.append({"tracking_number": num, "status": status})
+
     return statuses
 
 
 def process_tracking_csv(uploaded_file):
-    """Parse uploaded CSV and return message and tracking statuses."""
+    """Parse uploaded CSV and return message and rows with tracking/status."""
     if not uploaded_file or not uploaded_file.filename:
         return "No file uploaded", None
     try:
         df = pd.read_csv(uploaded_file)
         track_col = next(
-            (c for c in df.columns if c.lower().replace(" ", "") in ["tracking", "trackingnumber", "trackingno", "tracking#", "trackingnum"]),
+            (c for c in df.columns if c.strip().lower() == "tracking number"),
             None,
         )
-        if not track_col:
-            return "Tracking number column not found", None
+        if track_col is None:
+            return "Column 'Tracking Number' not found", None
+
         tracking_numbers = df[track_col].astype(str).tolist()
         statuses = fetch_tracking_statuses(tracking_numbers)
-        return f"Processed {uploaded_file.filename}", statuses
+        rows = [
+            {"Tracking Number": s["tracking_number"], "Status": s["status"]}
+            for s in statuses
+        ]
+
+        return f"Processed {uploaded_file.filename}", rows
     except FedExAPIError as exc:
         return str(exc), None
     except Exception as exc:

--- a/routes.py
+++ b/routes.py
@@ -2,7 +2,7 @@ import os
 from flask import Blueprint, render_template, request, redirect, url_for
 from flask_login import login_user, logout_user, login_required
 from logic.one_hour_report import count_assigned_tasks
-from logic.tracking_status import process_single_tracking_number
+from logic.tracking_status import process_tracking_csv
 from models import db, User
 
 bp = Blueprint("main", __name__)
@@ -99,21 +99,16 @@ def one_hour_report():
 @login_required
 def track_shipments():
     message = None
-    error = None
-    status = None
-    tracking_number = None
+    rows = None
     if request.method == "POST":
-        tracking_number = request.form.get("tracking_number")
-        message, status = process_single_tracking_number(tracking_number)
-        if not status:
-            error = message
+        uploaded_file = request.files.get("file")
+        message, rows = process_tracking_csv(uploaded_file)
     return render_template(
         "pages/track_shipments.html",
         title="Shipment Tracking",
-        message=message if status else None,
-        error=error,
-        tracking_number=tracking_number,
-        status=status,
+        message=message if rows else None,
+        error=None if rows else message,
+        rows=rows,
     )
 
 

--- a/templates/pages/track_shipments.html
+++ b/templates/pages/track_shipments.html
@@ -7,14 +7,15 @@
     {% if error and not message %}
     <p class="mb-4 text-red-600">{{ error }}</p>
     {% endif %}
-    <form method="post" class="mb-6">
-        <label for="tracking_number" class="block mb-2 font-medium">Enter Tracking Number</label>
-        <input id="tracking_number" name="tracking_number" type="text" class="border p-2 rounded w-full" />
-        <button type="submit" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Track</button>
+    <div id="loading" class="hidden mb-4">Processing...</div>
+    <form id="tracking-form" method="post" enctype="multipart/form-data" class="mb-6">
+        <label for="file" class="block mb-2 font-medium">Upload CSV</label>
+        <input id="file" name="file" type="file" class="border p-2 rounded w-full" />
+        <button type="submit" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Upload</button>
     </form>
 
-    {% if status %}
-    <h2 class="text-xl font-bold mt-4">Tracking Status</h2>
+    {% if rows %}
+    <h2 class="text-xl font-bold mt-4">Tracking Statuses</h2>
     <table class="table-auto border-collapse mt-2 palette-table">
         <thead>
             <tr>
@@ -23,12 +24,19 @@
             </tr>
         </thead>
         <tbody>
+            {% for row in rows %}
             <tr>
-                <td class="border px-4 py-2">{{ tracking_number }}</td>
-                <td class="border px-4 py-2">{{ status.status }}</td>
+                <td class="border px-4 py-2">{{ row['Tracking Number'] }}</td>
+                <td class="border px-4 py-2">{{ row['Status'] }}</td>
             </tr>
+            {% endfor %}
         </tbody>
     </table>
     {% endif %}
 </div>
+<script>
+document.getElementById('tracking-form').addEventListener('submit', function() {
+    document.getElementById('loading').classList.remove('hidden');
+});
+</script>
 {% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- handle up to 30 tracking numbers per request
- batch larger CSV uploads automatically
- document FedEx API limit in README
- simplify returned table to only show tracking number and status
- add a small loader indicator during file upload

## Testing
- `python -m py_compile app.py routes.py models.py logic/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6865cb3c6ca483278e3f54afedb03b3f