### PR TITLE
Add CSV upload and single tracking support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ The application includes a small custom CSS file under `static/styles/`. A color
 
 ## Shipment Tracking
 
-Authenticated users can upload a CSV file containing FedEx tracking numbers on the **Track Shipments** page. The application reads the "Tracking Number" column, fetches the status for each number from the FedEx Track API, and shows the same table with a new "Status" column.
+Authenticated users can either enter a single FedEx tracking number or upload a CSV file on the **Track Shipments** page. When uploading, the file must contain a column named "Tracking Number". The app reads every value in that column, fetches the status for each from the FedEx Track API, and displays a table with "Tracking Number" and "Status" columns.
 
 ### FedEx API configuration
 
 1. Sign up at the [FedEx Developer Portal](https://developer.fedex.com/) and create an application.
 2. Enable the *Track* service for the app and note the provided **Client ID** and **Client Secret**.
 3. Set environment variables `FEDEX_CLIENT_ID` and `FEDEX_CLIENT_SECRET` with these credentials before running the application.
-4. When a file is uploaded, the app obtains an OAuth token and calls `https://apis.fedex.com/track/v1/trackingnumbers` to fetch statuses.
+4. When a tracking number or file is submitted, the app obtains an OAuth token and calls `https://apis.fedex.com/track/v1/trackingnumbers` to fetch statuses.
 

--- a/logic/tracking_status.py
+++ b/logic/tracking_status.py
@@ -70,7 +70,7 @@ def fetch_tracking_statuses(tracking_numbers):
 
 
 def process_tracking_csv(uploaded_file):
-    """Parse uploaded CSV and return message and table rows with statuses."""
+    """Parse uploaded CSV and return message and tracking statuses."""
     if not uploaded_file or not uploaded_file.filename:
         return "No file uploaded", None
     try:
@@ -84,10 +84,8 @@ def process_tracking_csv(uploaded_file):
 
         tracking_numbers = df[track_col].astype(str).tolist()
         statuses = fetch_tracking_statuses(tracking_numbers)
-        status_map = {item["tracking_number"]: item["status"] for item in statuses}
-        df["Status"] = df[track_col].astype(str).map(status_map).fillna("Unknown")
 
-        return f"Processed {uploaded_file.filename}", df.to_dict(orient="records")
+        return f"Processed {uploaded_file.filename}", statuses
     except FedExAPIError as exc:
         return str(exc), None
     except Exception as exc:

--- a/templates/pages/track_shipments.html
+++ b/templates/pages/track_shipments.html
@@ -7,28 +7,48 @@
     {% if error and not message %}
     <p class="mb-4 text-red-600">{{ error }}</p>
     {% endif %}
+    <form method="post" class="mb-6">
+        <label for="tracking_number" class="block mb-2 font-medium">Enter Tracking Number</label>
+        <input id="tracking_number" name="tracking_number" type="text" class="border p-2 rounded w-full" />
+        <button type="submit" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Track</button>
+    </form>
+
     <form method="post" enctype="multipart/form-data" class="mb-6">
         <label for="file" class="block mb-2 font-medium">Upload CSV</label>
         <input id="file" name="file" type="file" class="border p-2 rounded w-full" />
         <button type="submit" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Upload</button>
     </form>
 
-    {% if rows %}
+    {% if status %}
+    <h2 class="text-xl font-bold mt-4">Tracking Status</h2>
+    <table class="table-auto border-collapse mt-2 palette-table">
+        <thead>
+            <tr>
+                <th class="border px-4 py-2">Tracking Number</th>
+                <th class="border px-4 py-2">Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td class="border px-4 py-2">{{ tracking_number }}</td>
+                <td class="border px-4 py-2">{{ status.status }}</td>
+            </tr>
+        </tbody>
+    </table>
+    {% elif rows %}
     <h2 class="text-xl font-bold mt-4">Tracking Statuses</h2>
     <table class="table-auto border-collapse mt-2 palette-table">
         <thead>
             <tr>
-                {% for col in rows[0].keys() %}
-                <th class="border px-4 py-2">{{ col }}</th>
-                {% endfor %}
+                <th class="border px-4 py-2">Tracking Number</th>
+                <th class="border px-4 py-2">Status</th>
             </tr>
         </thead>
         <tbody>
             {% for row in rows %}
             <tr>
-                {% for col in row.keys() %}
-                <td class="border px-4 py-2">{{ row[col] }}</td>
-                {% endfor %}
+                <td class="border px-4 py-2">{{ row.tracking_number }}</td>
+                <td class="border px-4 py-2">{{ row.status }}</td>
             </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- allow both single tracking number and CSV file upload for shipments
- switch `process_tracking_csv` back to returning rows with tracking number and status
- update tracking page to show single entry field and file upload
- document new workflow in README

## Testing
- `python -m py_compile routes.py logic/tracking_status.py`
- `pytest -q`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6866f89de4b88327b12deb5c3c13742b