### PR TITLE
Add spinner and cancel option for shipment uploads

### DIFF
--- a/logic/tracking_status.py
+++ b/logic/tracking_status.py
@@ -37,7 +37,7 @@ def _get_oauth_token():
         "client_id": client_id,
         "client_secret": client_secret,
     }
-    resp = requests.post(FEDEX_OAUTH_URL, data=data, timeout=10)
+    resp = requests.post(FEDEX_OAUTH_URL, data=data, timeout=30)
     if resp.status_code != 200:
         raise FedExAPIError(f"OAuth request failed: {resp.status_code} {resp.text}")
     return resp.json().get("access_token")
@@ -64,7 +64,7 @@ def fetch_tracking_statuses(tracking_numbers):
             ]
         }
         resp = requests.post(
-            FEDEX_TRACK_URL, json=body, headers=headers, timeout=10
+            FEDEX_TRACK_URL, json=body, headers=headers, timeout=30
         )
         if resp.status_code != 200:
             raise FedExAPIError(

--- a/static/js/track_shipments.js
+++ b/static/js/track_shipments.js
@@ -1,0 +1,43 @@
+
+document.addEventListener('DOMContentLoaded', () => {
+    const fileForm = document.getElementById('fileForm');
+    const loading = document.getElementById('loading');
+    const cancelBtn = document.getElementById('cancelBtn');
+    let controller;
+    if (fileForm) {
+        fileForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+            loading.classList.remove('hidden');
+            cancelBtn.classList.remove('hidden');
+            controller = new AbortController();
+            const formData = new FormData(fileForm);
+            fetch(fileForm.action, {
+                method: 'POST',
+                body: formData,
+                signal: controller.signal
+            })
+            .then(resp => resp.text())
+            .then(html => {
+                loading.classList.add('hidden');
+                cancelBtn.classList.add('hidden');
+                document.open();
+                document.write(html);
+                document.close();
+            })
+            .catch(err => {
+                loading.classList.add('hidden');
+                cancelBtn.classList.add('hidden');
+                if (err.name === 'AbortError') {
+                    alert('Upload canceled');
+                } else {
+                    alert('Upload failed');
+                }
+            });
+        });
+        cancelBtn.addEventListener('click', () => {
+            if (controller) {
+                controller.abort();
+            }
+        });
+    }
+});

--- a/templates/pages/track_shipments.html
+++ b/templates/pages/track_shipments.html
@@ -13,11 +13,20 @@
         <button type="submit" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Track</button>
     </form>
 
-    <form method="post" enctype="multipart/form-data" class="mb-6">
+    <form method="post" enctype="multipart/form-data" class="mb-6" id="fileForm">
         <label for="file" class="block mb-2 font-medium">Upload CSV</label>
         <input id="file" name="file" type="file" class="border p-2 rounded w-full" />
         <button type="submit" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Upload</button>
     </form>
+
+    <div id="loading" class="hidden flex items-center space-x-2">
+        <svg class="animate-spin h-5 w-5 text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+        </svg>
+        <span>Processing...</span>
+        <button id="cancelBtn" type="button" class="ml-4 px-2 py-1 border rounded hidden">Cancel</button>
+    </div>
 
     {% if status %}
     <h2 class="text-xl font-bold mt-4">Tracking Status</h2>
@@ -55,4 +64,5 @@
     </table>
     {% endif %}
 </div>
+<script src="{{ url_for('static', filename='js/track_shipments.js') }}"></script>
 {% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- add user feedback while uploading shipment files
- enable canceling an in‑progress upload
- bump FedEx API timeouts so large requests don't fail quickly

## Testing
- `python -m py_compile app.py models.py routes.py logic/tracking_status.py`

------
https://chatgpt.com/codex/tasks/task_e_686719c5a46c8327a14369bf771f741f