### PR TITLE
Integrate simple 3D warehouse demo

### DIFF
--- a/static/js/warehouse.js
+++ b/static/js/warehouse.js
@@ -1,0 +1,133 @@
+const container = document.getElementById('warehouse-container');
+const spinner = document.getElementById('warehouse-spinner');
+let scene, camera, renderer, forklift, controls, boxes = [];
+let darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+function createForklift(THREE) {
+    const group = new THREE.Group();
+    const bodyGeo = new THREE.BoxGeometry(1, 0.5, 2);
+    const bodyMat = new THREE.MeshStandardMaterial({color: 0xffaa00});
+    const body = new THREE.Mesh(bodyGeo, bodyMat);
+    body.position.y = 0.25;
+    group.add(body);
+
+    const mastGeo = new THREE.BoxGeometry(0.2, 1, 0.2);
+    const mast = new THREE.Mesh(mastGeo, bodyMat);
+    mast.position.set(0, 0.75, -0.8);
+    group.add(mast);
+
+    const forkGeo = new THREE.BoxGeometry(1, 0.05, 0.6);
+    const fork = new THREE.Mesh(forkGeo, bodyMat);
+    fork.position.set(0, 0.05, -1.1);
+    group.add(fork);
+
+    group.userData.velocity = 0;
+    group.userData.rotationSpeed = 0;
+    return group;
+}
+
+function handleTheme(THREE) {
+    if (darkMode) {
+        scene.background = new THREE.Color(0x111111);
+        scene.fog = new THREE.Fog(0x111111, 10, 50);
+    } else {
+        scene.background = new THREE.Color(0xbfd1e5);
+        scene.fog = new THREE.Fog(0xbfd1e5, 10, 50);
+    }
+}
+
+async function init() {
+    spinner.style.display = 'block';
+    const [THREE, {OrbitControls}] = await Promise.all([
+        import('https://raw.githubusercontent.com/mrdoob/three.js/r160/build/three.module.js'),
+        import('https://raw.githubusercontent.com/mrdoob/three.js/r160/examples/jsm/controls/OrbitControls.js')
+    ]);
+
+    scene = new THREE.Scene();
+    handleTheme(THREE);
+    camera = new THREE.PerspectiveCamera(75, container.clientWidth/container.clientHeight, 0.1, 1000);
+    camera.position.set(5,5,5);
+
+    renderer = new THREE.WebGLRenderer({antialias:true});
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    container.appendChild(renderer.domElement);
+
+    controls = new OrbitControls(camera, renderer.domElement);
+
+    const light = new THREE.HemisphereLight(0xffffff, darkMode?0x222222:0xffffff, 1);
+    scene.add(light);
+    const dir = new THREE.DirectionalLight(0xffffff, 0.5);
+    dir.position.set(3,10,5);
+    scene.add(dir);
+
+    const res = await fetch('/static/maps/warehouse_map.json');
+    const map = await res.json();
+
+    const floorGeo = new THREE.PlaneGeometry(map.floor.width, map.floor.height);
+    const floorMat = new THREE.MeshStandardMaterial({color: darkMode?0x444444:0xdddddd});
+    const floor = new THREE.Mesh(floorGeo, floorMat);
+    floor.rotation.x = -Math.PI/2;
+    scene.add(floor);
+
+    map.racks.forEach(r => {
+        const g = new THREE.BoxGeometry(r.width, r.height, r.depth);
+        const m = new THREE.MeshStandardMaterial({color:0x808080});
+        const rack = new THREE.Mesh(g,m);
+        rack.position.set(r.x, r.height/2, r.z);
+        rack.userData.isRack = true;
+        scene.add(rack);
+        boxes.push(new THREE.Box3().setFromObject(rack));
+    });
+
+    forklift = createForklift(THREE);
+    scene.add(forklift);
+    camera.lookAt(forklift.position);
+
+    window.addEventListener('resize', () => {
+        camera.aspect = container.clientWidth/container.clientHeight;
+        camera.updateProjectionMatrix();
+        renderer.setSize(container.clientWidth, container.clientHeight);
+    });
+
+    const keys = {};
+    window.addEventListener('keydown', e => { keys[e.key.toLowerCase()] = true; });
+    window.addEventListener('keyup', e => { keys[e.key.toLowerCase()] = false; });
+
+    function animate() {
+        requestAnimationFrame(animate);
+        const speed = 0.05;
+        const turn = 0.03;
+        if(keys['w'] || keys['arrowup']) forklift.userData.velocity = speed;
+        else if(keys['s'] || keys['arrowdown']) forklift.userData.velocity = -speed;
+        else forklift.userData.velocity = 0;
+        if(keys['a'] || keys['arrowleft']) forklift.rotation.y += turn;
+        if(keys['d'] || keys['arrowright']) forklift.rotation.y -= turn;
+        if(forklift.userData.velocity !== 0) {
+            const dir = new THREE.Vector3(0,0,-1).applyQuaternion(forklift.quaternion).multiplyScalar(forklift.userData.velocity);
+            forklift.position.add(dir);
+            const forkBox = new THREE.Box3().setFromObject(forklift);
+            for(const box of boxes){
+                if(forkBox.intersectsBox(box)){
+                    forklift.position.sub(dir);
+                    break;
+                }
+            }
+        }
+        renderer.render(scene, camera);
+    }
+    animate();
+    spinner.style.display = 'none';
+
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+        darkMode = e.matches;
+        handleTheme(THREE);
+    });
+
+    window.addEventListener('beforeunload', () => {
+        renderer.dispose();
+    });
+}
+
+if(container){
+    init();
+}

--- a/static/maps/warehouse_map.json
+++ b/static/maps/warehouse_map.json
@@ -1,0 +1,11 @@
+{
+  "floor": {"width": 40, "height": 40},
+  "racks": [
+    {"x": -10, "z": -5, "width": 2, "depth": 10, "height": 4},
+    {"x": 0, "z": -5, "width": 2, "depth": 10, "height": 4},
+    {"x": 10, "z": -5, "width": 2, "depth": 10, "height": 4},
+    {"x": -10, "z": 10, "width": 2, "depth": 10, "height": 4},
+    {"x": 0, "z": 10, "width": 2, "depth": 10, "height": 4},
+    {"x": 10, "z": 10, "width": 2, "depth": 10, "height": 4}
+  ]
+}

--- a/static/styles/custom.css
+++ b/static/styles/custom.css
@@ -40,3 +40,18 @@ header {
 .palette-table tbody tr:nth-child(even) {
     background-color: var(--color-background);
 }
+
+#warehouse-spinner {
+    transform: translate(-50%, -50%);
+}
+
+/* Dark mode adjustments */
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #111827;
+        color: #e5e7eb;
+    }
+    header {
+        background-color: #1f2937;
+    }
+}

--- a/templates/pages/greeting.html
+++ b/templates/pages/greeting.html
@@ -1,8 +1,8 @@
 {% include 'elements/header.html' %}
 <div class="container mx-auto px-4">
     <h1 class="text-2xl font-bold mb-4">Welcome!</h1>
-    <div id="roblox-scene" class="w-full h-96 border"></div>
+    <div id="warehouse-container" class="w-full h-96 md:h-[600px] border relative"></div>
+    <div id="warehouse-spinner" class="absolute left-1/2 top-1/2">Loading 3D warehouse...</div>
 </div>
-<script src="{{ url_for('static', filename='js/three.min.js') }}"></script>
-<script src="{{ url_for('static', filename='js/roblox_clone.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/warehouse.js') }}"></script>
 {% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- replace old Roblox-style scene with a warehouse canvas
- create a demo scene that loads Three.js modules on demand
- add a tiny warehouse map used to build racks
- adjust styles for spinner and dark mode

## Testing
- `python -m py_compile app.py gunicorn_config.py models.py routes.py`

------
https://chatgpt.com/codex/tasks/task_e_686721358f0c832795f9d4f56483b5c0