### PR TITLE
Fix 3D warehouse import paths

### DIFF
--- a/static/js/warehouse.js
+++ b/static/js/warehouse.js
@@ -39,8 +39,8 @@ function handleTheme(THREE) {
 async function init() {
     spinner.style.display = 'block';
     const [THREE, {OrbitControls}] = await Promise.all([
-        import('https://raw.githubusercontent.com/mrdoob/three.js/r160/build/three.module.js'),
-        import('https://raw.githubusercontent.com/mrdoob/three.js/r160/examples/jsm/controls/OrbitControls.js')
+        import('https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js'),
+        import('https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/OrbitControls.js')
     ]);
 
     scene = new THREE.Scene();


### PR DESCRIPTION
## Summary
- load three.js modules from jsDelivr CDN

## Testing
- `python -m compileall -q .`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_686723bc1744832795b13bbb138d0d54