### PR TITLE
Fix three.js import resolution

### DIFF
--- a/static/js/warehouse.js
+++ b/static/js/warehouse.js
@@ -39,7 +39,7 @@ function handleTheme(THREE) {
 async function init() {
     spinner.style.display = 'block';
     const [THREE, {OrbitControls}] = await Promise.all([
-        import('https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js'),
+        import('three'),
         import('https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/OrbitControls.js')
     ]);
 

--- a/templates/pages/greeting.html
+++ b/templates/pages/greeting.html
@@ -2,7 +2,14 @@
 <div class="container mx-auto px-4">
     <h1 class="text-2xl font-bold mb-4">Welcome!</h1>
     <div id="warehouse-container" class="w-full h-96 md:h-[600px] border relative"></div>
-    <div id="warehouse-spinner" class="absolute left-1/2 top-1/2">Loading 3D warehouse...</div>
+<div id="warehouse-spinner" class="absolute left-1/2 top-1/2">Loading 3D warehouse...</div>
 </div>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js"
+  }
+}
+</script>
 <script type="module" src="{{ url_for('static', filename='js/warehouse.js') }}"></script>
 {% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- ensure `OrbitControls.js` can resolve the `three` module
- load `three.js` via import map

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686729a6f17c83279228aafc3c5e926f