### PR TITLE
Implement Labor page mirroring Driver workflow

### DIFF
--- a/models.py
+++ b/models.py
@@ -19,6 +19,17 @@ class Driver(db.Model):
         return f"<Driver {self.driver_type}: {self.count}>"
 
 
+class Labor(db.Model):
+    """Represents a unit of labor available for assignments."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    labor_type = db.Column(db.String(80), nullable=False)
+    amount = db.Column(db.Integer, nullable=False, default=0)
+
+    def __repr__(self) -> str:  # pragma: no cover - simple representation
+        return f"<Labor {self.labor_type}: {self.amount}>"
+
+
 class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)

--- a/templates/elements/header.html
+++ b/templates/elements/header.html
@@ -19,5 +19,6 @@
             <a href="{{ url_for('main.dashboard') }}">Dashboard</a>
             <a href="{{ url_for('main.track_shipments') }}">Track Shipments</a>
             <a href="{{ url_for('main.drivers') }}">Drivers</a>
+            <a href="{{ url_for('main.labor') }}">Labor</a>
         </nav>
     </header>

--- a/templates/pages/labor.html
+++ b/templates/pages/labor.html
@@ -1,0 +1,43 @@
+{% include 'elements/header.html' %}
+<div class="container mx-auto px-4">
+    <h1 class="text-2xl font-bold mb-4">Labor</h1>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, msg in messages %}
+        <p class="mb-4 {% if category == 'success' %}text-success{% else %}text-error{% endif %}">{{ msg }}</p>
+        {% endfor %}
+    {% endif %}
+    {% endwith %}
+    <form method="post" class="mb-6">
+        <label for="labor_type" class="block mb-2 font-medium">Labor Type</label>
+        <input id="labor_type" name="labor_type" type="text" class="border p-2 rounded w-full" />
+        <label for="amount" class="block mb-2 font-medium mt-4">Amount</label>
+        <input id="amount" name="amount" type="number" class="border p-2 rounded w-full" />
+        <button type="submit" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Add Labor</button>
+    </form>
+    <table class="table-auto border-collapse palette-table">
+        <thead>
+            <tr>
+                <th class="border px-4 py-2 text-left">ID</th>
+                <th class="border px-4 py-2 text-left">Labor Type</th>
+                <th class="border px-4 py-2 text-left">Amount</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% if labor_entries %}
+            {% for l in labor_entries %}
+            <tr>
+                <td class="border px-4 py-2">{{ l.id }}</td>
+                <td class="border px-4 py-2">{{ l.labor_type }}</td>
+                <td class="border px-4 py-2">{{ l.amount }}</td>
+            </tr>
+            {% endfor %}
+        {% else %}
+            <tr>
+                <td class="border px-4 py-2" colspan="3">No labor entries yet.</td>
+            </tr>
+        {% endif %}
+        </tbody>
+    </table>
+</div>
+{% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- add `Labor` model
- create `/labor` route for adding and listing labor entries
- show Labor link in header navigation
- add `labor.html` template with flash messaging

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`
- `python - <<'PY'
from app import create_app
app=create_app()
for r in app.url_map.iter_rules():
    print(r.rule)
PY
`

------
https://chatgpt.com/codex/tasks/task_e_686876640af483279bdad6fb3d7e6faa