### PR TITLE
Add Staging Area page

### DIFF
--- a/models.py
+++ b/models.py
@@ -30,6 +30,17 @@ class Labor(db.Model):
         return f"<Labor {self.labor_type}: {self.amount}>"
 
 
+class Staging(db.Model):
+    """Represents a palette placed in a staging bin."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    palette = db.Column(db.String(80), nullable=False)
+    bin = db.Column(db.String(80), nullable=False)
+
+    def __repr__(self) -> str:  # pragma: no cover - simple representation
+        return f"<Staging {self.palette}:{self.bin}>"
+
+
 class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)

--- a/routes.py
+++ b/routes.py
@@ -6,7 +6,7 @@ from logic.tracking_status import (
     process_tracking_csv,
     process_single_tracking_number,
 )
-from models import db, User, Driver, Labor
+from models import db, User, Driver, Labor, Staging
 
 bp = Blueprint("main", __name__)
 
@@ -183,6 +183,30 @@ def labor():
         "pages/labor.html",
         title="Labor",
         labor_entries=all_labor,
+    )
+
+
+@bp.route("/staging", methods=["GET", "POST"])
+@login_required
+def staging():
+    """Create a new staging area record and list all existing records."""
+    if request.method == "POST":
+        palette = request.form.get("palette")
+        bin_value = request.form.get("bin")
+        if not palette or not bin_value:
+            flash("Palette and bin are required", "error")
+        else:
+            new_entry = Staging(palette=palette, bin=bin_value)
+            db.session.add(new_entry)
+            db.session.commit()
+            flash("Added to staging", "success")
+        return redirect(url_for("main.staging"))
+
+    all_entries = Staging.query.order_by(Staging.id.desc()).all()
+    return render_template(
+        "pages/staging.html",
+        title="Staging Area",
+        staging_entries=all_entries,
     )
 
 

--- a/templates/elements/header.html
+++ b/templates/elements/header.html
@@ -20,5 +20,6 @@
             <a href="{{ url_for('main.track_shipments') }}">Track Shipments</a>
             <a href="{{ url_for('main.drivers') }}">Drivers</a>
             <a href="{{ url_for('main.labor') }}">Labor</a>
+            <a href="{{ url_for('main.staging') }}">Staging Area</a>
         </nav>
     </header>

--- a/templates/pages/staging.html
+++ b/templates/pages/staging.html
@@ -1,0 +1,43 @@
+{% include 'elements/header.html' %}
+<div class="container mx-auto px-4">
+    <h1 class="text-2xl font-bold mb-4">Staging Area</h1>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, msg in messages %}
+        <p class="mb-4 {% if category == 'success' %}text-success{% else %}text-error{% endif %}">{{ msg }}</p>
+        {% endfor %}
+    {% endif %}
+    {% endwith %}
+    <form method="post" class="mb-6">
+        <label for="palette" class="block mb-2 font-medium">Palette</label>
+        <input id="palette" name="palette" type="text" class="border p-2 rounded w-full" />
+        <label for="bin" class="block mb-2 font-medium mt-4">Bin</label>
+        <input id="bin" name="bin" type="text" class="border p-2 rounded w-full" />
+        <button type="submit" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Add to Staging</button>
+    </form>
+    <table class="table-auto border-collapse palette-table">
+        <thead>
+            <tr>
+                <th class="border px-4 py-2 text-left">ID</th>
+                <th class="border px-4 py-2 text-left">Palette</th>
+                <th class="border px-4 py-2 text-left">Bin</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% if staging_entries %}
+            {% for s in staging_entries %}
+            <tr>
+                <td class="border px-4 py-2">{{ s.id }}</td>
+                <td class="border px-4 py-2">{{ s.palette }}</td>
+                <td class="border px-4 py-2">{{ s.bin }}</td>
+            </tr>
+            {% endfor %}
+        {% else %}
+            <tr>
+                <td class="border px-4 py-2" colspan="3">No staging entries yet.</td>
+            </tr>
+        {% endif %}
+        </tbody>
+    </table>
+</div>
+{% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- introduce `Staging` model
- add `/staging` route and template
- link new page from navigation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68687ae375688327ac19ff29f4f8c9ae