### PR TITLE
Add CSV quantity summarization

### DIFF
--- a/logic/eod_report.py
+++ b/logic/eod_report.py
@@ -33,3 +33,32 @@ def count_eod_production(uploaded_file):
 
     except Exception as e:
         return f"Error processing file: {str(e)}", None, None, None
+
+
+def count_total_pick(uploaded_file):
+    """Calculate total units picked from a CSV file.
+
+    The CSV must contain ``Transaction ID`` and ``Quantities`` columns. Rows
+    with a ``Transaction ID`` containing ``ATML``, ``AMZL``, ``AMXL``, ``TBA`` or
+    ``wholesale`` are ignored. The remaining ``Quantities`` values are summed
+    and returned as an integer.
+    """
+
+    if not uploaded_file or not uploaded_file.filename:
+        return None, None
+
+    try:
+        df = pd.read_csv(uploaded_file)
+
+        required_cols = {"Transaction ID", "Quantities"}
+        if not required_cols.issubset(df.columns):
+            return None, "Required columns not found"
+
+        mask = ~df["Transaction ID"].astype(str).str.contains(
+            "ATML|AMZL|AMXL|TBA|wholesale", case=False, na=False
+        )
+
+        total = int(df.loc[mask, "Quantities"].sum())
+        return total, f"Processed {uploaded_file.filename}"
+    except Exception as exc:
+        return None, f"Error processing file: {exc}"

--- a/routes.py
+++ b/routes.py
@@ -2,7 +2,7 @@ import os
 from flask import Blueprint, render_template, request, redirect, url_for, flash
 from flask_login import login_user, logout_user, login_required
 from logic.one_hour_report import count_assigned_tasks
-from logic.eod_report import count_eod_production
+from logic.eod_report import count_total_pick
 from logic.tracking_status import (
     process_tracking_csv,
     process_single_tracking_number,
@@ -102,24 +102,15 @@ def one_hour_report():
 @login_required
 def eod_report():
     message = None
-    units_picked = 1
-    units_Bundled = 1
-    units_folded = 1
+    units_picked = None
     if request.method == "POST":
         uploaded_file = request.files.get("file")
-        (
-            message,
-            units_picked,
-            units_Bundled,
-            units_folded,    
-        ) = count_eod_production(uploaded_file)
+        units_picked, message = count_total_pick(uploaded_file)
     return render_template(
         "pages/eod_report.html",
-        title="1-Hour Report",
+        title="EOD Report",
         message=message,
         units_picked=units_picked,
-        units_Bundled=units_Bundled,
-        units_folded=units_folded,
     )
 
 

--- a/templates/pages/eod_report.html
+++ b/templates/pages/eod_report.html
@@ -6,23 +6,11 @@
     {% endif %}
     <form method="post" enctype="multipart/form-data" class="mb-6">
         <label for="file" class="block mb-2 font-medium">Upload File</label>
-        <input id="file" name="file" type="file" class="border p-2 rounded w-full" />
-        <button type="submit" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Upload</button>
+        <input id="file" name="file" type="file" accept=".csv" class="border p-2 rounded w-full" />
+        <button type="submit" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Upload &amp; Calculate</button>
     </form>
     {% if units_picked is not none %}
-    <h2 class="text-xl font-bold mt-4">Units Picked</h2>
-    <p style="color: rgb(255, 0, 0);">3096</p>
-    <p>{{units_picked}}</p>
-    {% endif %}
-    {% if units_Bundled is not none %}
-    <h2 class="text-xl font-bold mt-4">Units Bundled</h2>
-    <p style="color: rgb(255, 0, 0);">1358</p>
-    <p>{{units_Bundled}}</p>
-    {% endif %}
-    {% if units_folded is not none %}
-    <h2 class="text-xl font-bold mt-4">Units Folded</h2>
-    <p style="color: rgb(255, 0, 0);">168</p>
-    <p>{{units_folded}}</p>
+    <p class="font-bold">Units Picked: {{ units_picked }}</p>
     {% endif %}
 
 </div>


### PR DESCRIPTION
## Summary
- implement `count_total_pick` to aggregate quantities while filtering transaction IDs
- update `/eod-report` route to process the uploaded CSV using this new function
- simplify EOD report template with single upload field and result output

## Testing
- `python -m py_compile routes.py logic/eod_report.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af012d6548327bb7fe0d042234250