### PR TITLE
Add Labor CRUD management

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ Authenticated users can either enter a single FedEx tracking number or upload a 
 3. Set environment variables `FEDEX_CLIENT_ID` and `FEDEX_CLIENT_SECRET` with these credentials before running the application.
 4. When a tracking number or file is submitted, the app obtains an OAuth token and calls `https://apis.fedex.com/track/v1/trackingnumbers` to fetch statuses.
 
+## Labor management
+
+Users can record labor assignments linked to an existing work type.  Each entry stores the job name and how many people are assigned.  Use the **Labor** page from the navigation bar to create, edit or delete entries.
+

--- a/models.py
+++ b/models.py
@@ -36,3 +36,13 @@ class WorkType(db.Model):
     name = db.Column(db.String(128), nullable=False, unique=True)
     # description = db.Column(db.String(256), nullable=True)
 
+
+class Labor(db.Model):
+    __tablename__ = "labors"
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(128), nullable=False)
+    num_people = db.Column(db.Integer, nullable=False)
+    work_type_id = db.Column(db.Integer, db.ForeignKey("work_types.id"), nullable=False)
+
+    work_type = db.relationship("WorkType", backref=db.backref("labors", lazy=True))
+

--- a/templates/elements/header.html
+++ b/templates/elements/header.html
@@ -16,6 +16,7 @@
             <a href="{{ url_for('main.dashboard') }}">Dashboard</a>
             <a href="{{ url_for('main.track_shipments') }}">Track Shipments</a>
             <a href="{{ url_for('main.list_work_types') }}">Work Types</a>
+            <a href="{{ url_for('main.list_labors') }}">Labor</a>
             {% else %}
             <a href="{{ url_for('main.greeting') }}">Greeting</a>
             <a href="{{ url_for('main.create_user') }}">Create User</a>

--- a/templates/pages/labor_form.html
+++ b/templates/pages/labor_form.html
@@ -1,0 +1,28 @@
+{% include 'elements/header.html' %}
+<div class="container mx-auto px-4">
+    <h1 class="text-2xl font-bold mb-4">{{ 'Edit' if labor else 'Create' }} Labor</h1>
+    {% if message %}
+    <p class="mb-4 text-error">{{ message }}</p>
+    {% endif %}
+    <form method="post" class="space-y-4">
+        <div>
+            <label for="name" class="block mb-1 font-medium">Name</label>
+            <input id="name" name="name" type="text" value="{{ labor.name if labor else '' }}" class="border p-2 rounded w-full" />
+        </div>
+        <div>
+            <label for="num_people" class="block mb-1 font-medium">Number of People</label>
+            <input id="num_people" name="num_people" type="number" value="{{ labor.num_people if labor else '' }}" class="border p-2 rounded w-full" />
+        </div>
+        <div>
+            <label for="work_type_id" class="block mb-1 font-medium">Work Type</label>
+            <select id="work_type_id" name="work_type_id" class="border p-2 rounded w-full">
+                <option value="">Select...</option>
+                {% for wt in work_types %}
+                <option value="{{ wt.id }}" {% if labor and labor.work_type_id == wt.id %}selected{% endif %}>{{ wt.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded">{{ 'Update' if labor else 'Create' }}</button>
+    </form>
+</div>
+{% include 'elements/footer.html' %}

--- a/templates/pages/labor_list.html
+++ b/templates/pages/labor_list.html
@@ -1,0 +1,35 @@
+{% include 'elements/header.html' %}
+<div class="container mx-auto px-4">
+    <h1 class="text-2xl font-bold mb-4">Labor</h1>
+    <a href="{{ url_for('main.create_labor') }}" class="mb-4 inline-block px-4 py-2 bg-blue-500 text-white rounded">New Labor</a>
+    {% if labors %}
+    <table class="table-auto border-collapse palette-table mt-2">
+        <thead>
+            <tr>
+                <th class="border px-4 py-2">Name</th>
+                <th class="border px-4 py-2">Work Type</th>
+                <th class="border px-4 py-2">People</th>
+                <th class="border px-4 py-2">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for labor in labors %}
+            <tr>
+                <td class="border px-4 py-2">{{ labor.name }}</td>
+                <td class="border px-4 py-2">{{ labor.work_type.name }}</td>
+                <td class="border px-4 py-2">{{ labor.num_people }}</td>
+                <td class="border px-4 py-2">
+                    <a href="{{ url_for('main.edit_labor', labor_id=labor.id) }}" class="text-blue-600 mr-2">Edit</a>
+                    <form method="post" action="{{ url_for('main.delete_labor', labor_id=labor.id) }}" style="display:inline">
+                        <button type="submit" class="text-red-600" onclick="return confirm('Delete this labor entry?');">Delete</button>
+                    </form>
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p>No labor entries found.</p>
+    {% endif %}
+</div>
+{% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- add `Labor` model to store job name, work type and number of people
- implement CRUD routes and templates for labor entries
- expose the new page through the nav bar
- document labor management in README

## Testing
- `python -m py_compile models.py routes.py app.py`
- *(failed: `python app.py` - missing flask)*

------
https://chatgpt.com/codex/tasks/task_e_6876f0b1aa088327a0f38082e436ef5f