### PR TITLE
Add staged inventory CRUD linked to jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ Authenticated users can either enter a single FedEx tracking number or upload a 
 
 Users can record labor assignments linked to an existing work type.  Each entry stores the job name and how many people are assigned.  Use the **Labor** page from the navigation bar to create, edit or delete entries.
 
+## Staged inventory
+
+Keep track of pallets or bins currently sitting on the warehouse floor.  Each entry stores the product name, quantity and the job it is associated with.  Use the **Staged Inventory** page to record, update or remove these items.
+

--- a/models.py
+++ b/models.py
@@ -46,3 +46,18 @@ class Labor(db.Model):
 
     work_type = db.relationship("WorkType", backref=db.backref("labors", lazy=True))
 
+
+class StagedInventory(db.Model):
+    """Inventory sitting on the floor waiting to be processed."""
+
+    __tablename__ = "staged_inventory"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(128), nullable=False)
+    amount = db.Column(db.Integer, nullable=False)
+    labor_id = db.Column(
+        db.Integer, db.ForeignKey("labors.id"), nullable=False
+    )
+
+    labor = db.relationship("Labor", backref=db.backref("staged_items", lazy=True))
+

--- a/templates/elements/header.html
+++ b/templates/elements/header.html
@@ -17,6 +17,7 @@
             <a href="{{ url_for('main.track_shipments') }}">Track Shipments</a>
             <a href="{{ url_for('main.list_work_types') }}">Work Types</a>
             <a href="{{ url_for('main.list_labors') }}">Labor</a>
+            <a href="{{ url_for('main.list_staged_items') }}">Staged Inventory</a>
             {% else %}
             <a href="{{ url_for('main.greeting') }}">Greeting</a>
             <a href="{{ url_for('main.create_user') }}">Create User</a>

--- a/templates/pages/staged_inventory_form.html
+++ b/templates/pages/staged_inventory_form.html
@@ -1,0 +1,28 @@
+{% include 'elements/header.html' %}
+<div class="container mx-auto px-4">
+    <h1 class="text-2xl font-bold mb-4">{{ 'Edit' if item else 'Create' }} Staged Inventory</h1>
+    {% if message %}
+    <p class="mb-4 text-error">{{ message }}</p>
+    {% endif %}
+    <form method="post" class="space-y-4">
+        <div>
+            <label for="name" class="block mb-1 font-medium">Name</label>
+            <input id="name" name="name" type="text" value="{{ item.name if item else '' }}" class="border p-2 rounded w-full" />
+        </div>
+        <div>
+            <label for="amount" class="block mb-1 font-medium">Amount</label>
+            <input id="amount" name="amount" type="number" value="{{ item.amount if item else '' }}" class="border p-2 rounded w-full" />
+        </div>
+        <div>
+            <label for="labor_id" class="block mb-1 font-medium">Job</label>
+            <select id="labor_id" name="labor_id" class="border p-2 rounded w-full">
+                <option value="">Select...</option>
+                {% for lb in labors %}
+                <option value="{{ lb.id }}" {% if item and item.labor_id == lb.id %}selected{% endif %}>{{ lb.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded">{{ 'Update' if item else 'Create' }}</button>
+    </form>
+</div>
+{% include 'elements/footer.html' %}

--- a/templates/pages/staged_inventory_list.html
+++ b/templates/pages/staged_inventory_list.html
@@ -1,0 +1,35 @@
+{% include 'elements/header.html' %}
+<div class="container mx-auto px-4">
+    <h1 class="text-2xl font-bold mb-4">Staged Inventory</h1>
+    <a href="{{ url_for('main.create_staged_item') }}" class="mb-4 inline-block px-4 py-2 bg-blue-500 text-white rounded">New Entry</a>
+    {% if items %}
+    <table class="table-auto border-collapse palette-table mt-2">
+        <thead>
+            <tr>
+                <th class="border px-4 py-2">Name</th>
+                <th class="border px-4 py-2">Amount</th>
+                <th class="border px-4 py-2">Job</th>
+                <th class="border px-4 py-2">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for item in items %}
+            <tr>
+                <td class="border px-4 py-2">{{ item.name }}</td>
+                <td class="border px-4 py-2">{{ item.amount }}</td>
+                <td class="border px-4 py-2">{{ item.labor.name }}</td>
+                <td class="border px-4 py-2">
+                    <a href="{{ url_for('main.edit_staged_item', item_id=item.id) }}" class="text-blue-600 mr-2">Edit</a>
+                    <form method="post" action="{{ url_for('main.delete_staged_item', item_id=item.id) }}" style="display:inline">
+                        <button type="submit" class="text-red-600" onclick="return confirm('Delete this entry?');">Delete</button>
+                    </form>
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p>No staged inventory entries found.</p>
+    {% endif %}
+</div>
+{% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- add StagedInventory model for floor inventory
- implement CRUD routes for staged inventory
- add templates to create and list staged items
- expose new navigation link
- document staged inventory usage in README

## Testing
- `python -m py_compile app.py models.py routes.py logic/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876f3f41c708327b814289de79b0373