### PR TITLE
Move dotenv load before route import

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,12 +1,12 @@
+from dotenv import load_dotenv
+load_dotenv()
 from flask import Flask
 from models import db, login_manager
 from routes import bp
-from dotenv import load_dotenv
 import os
 
 
 def create_app():
-    load_dotenv()
     app = Flask(__name__)
     app.config["SECRET_KEY"] = os.getenv("SECRET_KEY")
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///datawasher.db"


### PR DESCRIPTION
## Summary
- initialize environment variables before loading routes

## Testing
- `python -m py_compile app.py gunicorn_config.py logic/__init__.py logic/eod_report.py logic/one_hour_report.py logic/tracking_status.py models.py routes.py`


------
https://chatgpt.com/codex/tasks/task_e_6879971626d483278fc7ddc710d64d57