### PR TITLE
Add OpenCV barcode scanning page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ tzdata==2025.2
 Werkzeug==3.1.3
 WTForms==3.2.1
 requests==2.31.0
+opencv-contrib-python-headless==4.10.0.84

--- a/routes.py
+++ b/routes.py
@@ -1,4 +1,6 @@
 import os
+import cv2
+import numpy as np
 from flask import (
     Blueprint,
     render_template,
@@ -153,6 +155,31 @@ def track_shipments():
     )
 
 
+
+@bp.route("/barcode-scan", methods=["GET", "POST"])
+@login_required
+def barcode_scan():
+    message = None
+    decoded = None
+    if request.method == "POST":
+        uploaded_file = request.files.get("file")
+        if uploaded_file and uploaded_file.filename:
+            file_bytes = np.frombuffer(uploaded_file.read(), np.uint8)
+            image = cv2.imdecode(file_bytes, cv2.IMREAD_GRAYSCALE)
+            detector = cv2.barcode_BarcodeDetector()
+            ok, decoded_info, _, _ = detector.detectAndDecode(image)
+            if ok and decoded_info:
+                decoded = decoded_info[0]
+            else:
+                message = "No barcode detected"
+        else:
+            message = "No file uploaded"
+    return render_template(
+        "pages/barcode_scan.html",
+        title="Barcode Scan",
+        message=message,
+        decoded=decoded,
+    )
 
 @bp.route("/greet/<name>")
 def greet(name):

--- a/templates/elements/header.html
+++ b/templates/elements/header.html
@@ -18,6 +18,7 @@
             <a href="{{ url_for('main.list_work_types') }}">Work Types</a>
             <a href="{{ url_for('main.list_labors') }}">Labor</a>
             <a href="{{ url_for('main.list_staged_items') }}">Staged Inventory</a>
+            <a href="{{ url_for('main.barcode_scan') }}">Barcode Scan</a>
             {% else %}
             <a href="{{ url_for('main.greeting') }}">Greeting</a>
             <a href="{{ url_for('main.create_user') }}">Create User</a>

--- a/templates/pages/barcode_scan.html
+++ b/templates/pages/barcode_scan.html
@@ -1,0 +1,15 @@
+{% include 'elements/header.html' %}
+<div class="container mx-auto px-4">
+    <h1 class="text-2xl font-bold mb-4">Barcode Scan</h1>
+    {% if message %}
+    <div class="text-red-600 mb-4">{{ message }}</div>
+    {% endif %}
+    {% if decoded %}
+    <div class="mb-4">Decoded barcode: <span class="font-mono">{{ decoded }}</span></div>
+    {% endif %}
+    <form method="post" enctype="multipart/form-data" class="space-y-4">
+        <input type="file" name="file" accept="image/*" class="block" />
+        <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Scan</button>
+    </form>
+</div>
+{% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- add `opencv-contrib-python-headless` to support OpenCV features
- introduce `/barcode-scan` route using `cv2.barcode_BarcodeDetector` for 1D barcode decoding
- provide HTML template and navigation link for the new barcode scan page

## Testing
- `pip install opencv-contrib-python-headless==4.10.0.84`
- `python -m py_compile routes.py`
- `python - <<'PY'\nimport cv2\nprint('version', cv2.__version__)\nprint('has detector', hasattr(cv2, 'barcode_BarcodeDetector'))\nPY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d579ab1ac8327a81d2eeaef4adfb6