### PR TITLE
Add OpenCV webcam demo

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -181,6 +181,11 @@ def barcode_scan():
         decoded=decoded,
     )
 
+
+@bp.route("/webcam-demo")
+def webcam_demo():
+    return render_template("pages/webcam_demo.html", title="Webcam Demo")
+
 @bp.route("/greet/<name>")
 def greet(name):
     return f"<p>Hello, {name}!</p>"

--- a/static/js/webcam_demo.js
+++ b/static/js/webcam_demo.js
@@ -1,0 +1,32 @@
+const video = document.getElementById('videoInput');
+const canvas = document.getElementById('canvasOutput');
+const ctx = canvas.getContext('2d');
+
+function onOpenCvReady() {
+  navigator.mediaDevices.getUserMedia({ video: true, audio: false })
+    .then(stream => {
+      video.srcObject = stream;
+      video.play();
+      requestAnimationFrame(processVideo);
+    })
+    .catch(err => console.error('getUserMedia() failed:', err));
+}
+
+function processVideo() {
+  const src = new cv.Mat(video.height, video.width, cv.CV_8UC4);
+  const dst = new cv.Mat(video.height, video.width, cv.CV_8UC1);
+
+  ctx.drawImage(video, 0, 0, video.width, video.height);
+  src.data.set(ctx.getImageData(0, 0, video.width, video.height).data);
+
+  cv.cvtColor(src, dst, cv.COLOR_RGBA2GRAY);
+  cv.imshow('canvasOutput', dst);
+
+  src.delete();
+  dst.delete();
+  requestAnimationFrame(processVideo);
+}
+
+Module = {
+  onRuntimeInitialized: onOpenCvReady
+};

--- a/templates/elements/header.html
+++ b/templates/elements/header.html
@@ -19,10 +19,12 @@
             <a href="{{ url_for('main.list_labors') }}">Labor</a>
             <a href="{{ url_for('main.list_staged_items') }}">Staged Inventory</a>
             <a href="{{ url_for('main.barcode_scan') }}">Barcode Scan</a>
+            <a href="{{ url_for('main.webcam_demo') }}">Webcam Demo</a>
             {% else %}
             <a href="{{ url_for('main.greeting') }}">Greeting</a>
             <a href="{{ url_for('main.create_user') }}">Create User</a>
             <a href="{{ url_for('main.login') }}">Login</a>
+            <a href="{{ url_for('main.webcam_demo') }}">Webcam Demo</a>
             {% endif %}
         </nav>
     </header>

--- a/templates/pages/webcam_demo.html
+++ b/templates/pages/webcam_demo.html
@@ -1,0 +1,9 @@
+{% include 'elements/header.html' %}
+<div class="container mx-auto px-4">
+    <h1 class="text-2xl font-bold mb-4">Webcam Demo</h1>
+    <video id="videoInput" width="640" height="480" autoplay class="border"></video>
+    <canvas id="canvasOutput" width="640" height="480" class="border"></canvas>
+</div>
+<script async src="https://docs.opencv.org/4.x/opencv.js"></script>
+<script src="{{ url_for('static', filename='js/webcam_demo.js') }}"></script>
+{% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- add webcam demo page powered by OpenCV.js
- include navigation links for the new webcam page
- serve client-side script to process webcam frames in grayscale

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d5dbe5a7c83279f838bfa3e21812e