### PR TITLE
Add webcam barcode scanner

### DIFF
--- a/static/js/webcam_demo.js
+++ b/static/js/webcam_demo.js
@@ -1,32 +1,44 @@
-const video = document.getElementById('videoInput');
-const canvas = document.getElementById('canvasOutput');
-const ctx = canvas.getContext('2d');
+document.addEventListener('DOMContentLoaded', () => {
+  const results = document.getElementById('barcode-results');
 
-function onOpenCvReady() {
-  navigator.mediaDevices.getUserMedia({ video: true, audio: false })
-    .then(stream => {
-      video.srcObject = stream;
-      video.play();
-      requestAnimationFrame(processVideo);
-    })
-    .catch(err => console.error('getUserMedia() failed:', err));
-}
+  Quagga.init({
+    inputStream: {
+      type: 'LiveStream',
+      target: document.querySelector('#video-container'),
+      constraints: {
+        width: 640,
+        height: 480,
+        facingMode: 'environment'
+      }
+    },
+    decoder: {
+      readers: [
+        'code_128_reader',
+        'ean_reader',
+        'ean_8_reader',
+        'code_39_reader',
+        'code_39_vin_reader',
+        'codabar_reader',
+        'upc_reader',
+        'upc_e_reader',
+        'i2of5_reader',
+        '2of5_reader',
+        'code_93_reader'
+      ]
+    }
+  }, err => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+    Quagga.start();
+  });
 
-function processVideo() {
-  const src = new cv.Mat(video.height, video.width, cv.CV_8UC4);
-  const dst = new cv.Mat(video.height, video.width, cv.CV_8UC1);
+  Quagga.onDetected(data => {
+    const code = data.codeResult.code;
+    const div = document.createElement('div');
+    div.textContent = code;
+    results.appendChild(div);
+  });
+});
 
-  ctx.drawImage(video, 0, 0, video.width, video.height);
-  src.data.set(ctx.getImageData(0, 0, video.width, video.height).data);
-
-  cv.cvtColor(src, dst, cv.COLOR_RGBA2GRAY);
-  cv.imshow('canvasOutput', dst);
-
-  src.delete();
-  dst.delete();
-  requestAnimationFrame(processVideo);
-}
-
-Module = {
-  onRuntimeInitialized: onOpenCvReady
-};

--- a/templates/pages/webcam_demo.html
+++ b/templates/pages/webcam_demo.html
@@ -1,9 +1,11 @@
 {% include 'elements/header.html' %}
 <div class="container mx-auto px-4">
-    <h1 class="text-2xl font-bold mb-4">Webcam Demo</h1>
-    <video id="videoInput" width="640" height="480" autoplay class="border"></video>
-    <canvas id="canvasOutput" width="640" height="480" class="border"></canvas>
+    <h1 class="text-2xl font-bold mb-4">Webcam Barcode Scanner</h1>
+    <div class="flex">
+        <div id="video-container" class="border"></div>
+        <div id="barcode-results" class="ml-4 text-green-600"></div>
+    </div>
 </div>
-<script async src="https://docs.opencv.org/4.x/opencv.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/quagga/0.12.1/quagga.min.js"></script>
 <script src="{{ url_for('static', filename='js/webcam_demo.js') }}"></script>
 {% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- Replace OpenCV demo with live barcode scanner using QuaggaJS
- Display scanned barcode values in green alongside the webcam stream

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d60a4db808327ba6be5886e53c14f