### PR TITLE
Add barcode comparison with color feedback

### DIFF
--- a/static/js/webcam_demo.js
+++ b/static/js/webcam_demo.js
@@ -1,5 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
   const results = document.getElementById('barcode-results');
+  const primary = document.getElementById('primary-barcode');
+  const video = document.getElementById('video-container');
+  let primaryCode = null;
+  let lastCode = null;
 
   Quagga.init({
     inputStream: {
@@ -36,9 +40,27 @@ document.addEventListener('DOMContentLoaded', () => {
 
   Quagga.onDetected(data => {
     const code = data.codeResult.code;
+    if (code === lastCode) {
+      return;
+    }
+    lastCode = code;
+
+    if (!primaryCode) {
+      primaryCode = code;
+      primary.textContent = `Primary Barcode: ${code}`;
+      video.classList.remove('border-red-500', 'border-gray-300');
+      video.classList.add('border-green-500');
+      return;
+    }
+
+    const match = code === primaryCode;
     const div = document.createElement('div');
     div.textContent = code;
+    div.className = match ? 'text-green-600' : 'text-red-600';
     results.appendChild(div);
+
+    video.classList.remove('border-red-500', 'border-green-500', 'border-gray-300');
+    video.classList.add(match ? 'border-green-500' : 'border-red-500');
   });
 });
 

--- a/templates/pages/webcam_demo.html
+++ b/templates/pages/webcam_demo.html
@@ -2,8 +2,11 @@
 <div class="container mx-auto px-4">
     <h1 class="text-2xl font-bold mb-4">Webcam Barcode Scanner</h1>
     <div class="flex">
-        <div id="video-container" class="border"></div>
-        <div id="barcode-results" class="ml-4 text-green-600"></div>
+        <div id="video-container" class="border-4 border-gray-300"></div>
+        <div class="ml-4">
+            <div id="primary-barcode" class="font-bold mb-2"></div>
+            <div id="barcode-results"></div>
+        </div>
     </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/quagga/0.12.1/quagga.min.js"></script>


### PR DESCRIPTION
## Summary
- capture first scanned barcode as the primary reference
- highlight matching scans in green and mismatches in red

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d627d8ae083279b3eb176c7a85466