### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/static/styles/custom.css
+++ b/static/styles/custom.css
@@ -45,3 +45,9 @@ header {
     transform: translate(-50%, -50%);
 }
 
+/* Ensure images scale on small screens */
+img {
+    max-width: 100%;
+    height: auto;
+}
+

--- a/templates/elements/header.html
+++ b/templates/elements/header.html
@@ -2,12 +2,13 @@
 <html>
 <head>
     <title>{{ title|default('DataWasher') }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="{{ url_for('static', filename='styles/custom.css') }}">
 </head>
 <body class="pt-16">
     <header class="fixed top-0 left-0 w-full shadow py-2">
-        <nav class="flex space-x-4 px-4">
+        <nav class="flex space-x-4 px-4 overflow-x-auto whitespace-nowrap">
             {% if current_user.is_authenticated %}
             <a href="{{ url_for('main.logout') }}">Logout</a>
             <a href="{{ url_for('main.home') }}">Home</a>


### PR DESCRIPTION
## Summary
- add viewport metadata and make navigation scroll on narrow screens
- scale images to the width of the display

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ec8cb462c8327a6a5093fe2f8ef47