### PR TITLE
Make primary barcode editable in webcam demo

### DIFF
--- a/static/js/webcam_demo.js
+++ b/static/js/webcam_demo.js
@@ -1,9 +1,17 @@
 document.addEventListener('DOMContentLoaded', () => {
   const results = document.getElementById('barcode-results');
-  const primary = document.getElementById('primary-barcode');
+  const primaryInput = document.getElementById('primary-barcode-input');
   const video = document.getElementById('video-container');
-  let primaryCode = null;
+  let primaryCode = '';
   let lastCode = null;
+
+  primaryInput.addEventListener('input', () => {
+    primaryCode = primaryInput.value.trim();
+    if (!primaryCode) {
+      video.classList.remove('border-red-500', 'border-green-500');
+      video.classList.add('border-gray-300');
+    }
+  });
 
   Quagga.init({
     inputStream: {
@@ -47,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (!primaryCode) {
       primaryCode = code;
-      primary.textContent = `Primary Barcode: ${code}`;
+      primaryInput.value = code;
       video.classList.remove('border-red-500', 'border-gray-300');
       video.classList.add('border-green-500');
       return;

--- a/templates/pages/webcam_demo.html
+++ b/templates/pages/webcam_demo.html
@@ -4,7 +4,8 @@
     <div class="flex">
         <div id="video-container" class="border-4 border-gray-300"></div>
         <div class="ml-4">
-            <div id="primary-barcode" class="font-bold mb-2"></div>
+            <label for="primary-barcode-input" class="font-bold block mb-2">Primary Barcode:</label>
+            <input id="primary-barcode-input" type="text" class="border p-1 mb-2 w-full" />
             <div id="barcode-results"></div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Add text input for the primary barcode on the webcam demo page
- Update scanner logic to populate and use the editable input
- Reset scanner border when primary code cleared

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ed333fad483278cb70e1eb6a36912