### PR TITLE
Reduce false barcode scans in webcam demo

### DIFF
--- a/static/js/webcam_demo.js
+++ b/static/js/webcam_demo.js
@@ -5,6 +5,18 @@ document.addEventListener('DOMContentLoaded', () => {
   let primaryCode = '';
   let lastCode = null;
 
+  const ERROR_THRESHOLD = 0.1;
+
+  const computeAverageError = decodedCodes => {
+    const errors = decodedCodes
+      .filter(code => code.error !== undefined)
+      .map(code => code.error);
+    if (!errors.length) {
+      return 0;
+    }
+    return errors.reduce((sum, err) => sum + err, 0) / errors.length;
+  };
+
   primaryInput.addEventListener('input', () => {
     primaryCode = primaryInput.value.trim();
     if (!primaryCode) {
@@ -48,6 +60,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   Quagga.onDetected(data => {
     const code = data.codeResult.code;
+    const error = computeAverageError(data.codeResult.decodedCodes || []);
+    if (error > ERROR_THRESHOLD) {
+      return;
+    }
     if (code === lastCode) {
       return;
     }


### PR DESCRIPTION
## Summary
- filter out low-confidence barcode detections using Quagga's error metrics to reduce fake scans

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ed62b400c8327b8b76c3e7b5003cd