### PR TITLE
Make webcam demo responsive

### DIFF
--- a/static/styles/custom.css
+++ b/static/styles/custom.css
@@ -51,3 +51,8 @@ img {
     height: auto;
 }
 
+#video-container video {
+    width: 100%;
+    height: auto;
+}
+

--- a/templates/pages/webcam_demo.html
+++ b/templates/pages/webcam_demo.html
@@ -1,9 +1,9 @@
 {% include 'elements/header.html' %}
 <div class="container mx-auto px-4">
     <h1 class="text-2xl font-bold mb-4">Webcam Barcode Scanner</h1>
-    <div class="flex">
-        <div id="video-container" class="border-4 border-gray-300"></div>
-        <div class="ml-4">
+    <div class="flex flex-col md:flex-row">
+        <div id="video-container" class="border-4 border-gray-300 w-full md:w-2/3"></div>
+        <div class="mt-4 md:mt-0 md:ml-4 w-full md:w-1/3">
             <label for="primary-barcode-input" class="font-bold block mb-2">Primary Barcode:</label>
             <input id="primary-barcode-input" type="text" class="border p-1 mb-2 w-full" />
             <div id="barcode-results"></div>


### PR DESCRIPTION
## Summary
- Improve layout of webcam demo to show video and barcode input on small screens
- Scale embedded video to fit its container

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890062351248327ad5fe79806abd819