### PR TITLE
Improve barcode scanner responsiveness

### DIFF
--- a/static/styles/custom.css
+++ b/static/styles/custom.css
@@ -68,3 +68,20 @@ img {
     height: 100%;
 }
 
+#interactive {
+    position: relative;
+}
+
+#interactive video {
+    width: 100%;
+    height: auto;
+}
+
+#interactive canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+

--- a/templates/pages/barcode_scan.html
+++ b/templates/pages/barcode_scan.html
@@ -1,12 +1,12 @@
 {% include 'elements/header.html' %}
-<div class="container mx-auto px-4">
+<div class="container mx-auto px-4 flex flex-col h-[calc(100vh-4rem)]">
   <h1 class="text-2xl font-bold mb-4">Barcode Scanner</h1>
-  <div id="interactive" class="w-full max-w-md mx-auto"></div>
+  <div id="interactive" class="w-full flex-grow"></div>
   <div class="mt-4">
     <label for="scan-result" class="font-bold block mb-2">Last Scan:</label>
     <input id="scan-result" type="text" class="border p-1 w-full" readonly />
   </div>
-  <div id="scan-history" class="mt-4 max-h-60 overflow-y-auto border p-2"></div>
+  <div id="scan-history" class="mt-4 h-40 overflow-y-auto border p-2"></div>
 </div>
 <script src="https://unpkg.com/@ericblade/quagga2/dist/quagga.js"></script>
 <script src="{{ url_for('static', filename='js/scanner.js') }}"></script>


### PR DESCRIPTION
## Summary
- Make barcode scanner layout fill viewport and show scan results without extra scrolling
- Ensure Quagga video scales on small screens for better mobile support

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892854799fc832786470378353e70cc