### PR TITLE
Add ZXing barcode scanning demo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,55 @@
     "": {
       "name": "datawasher",
       "version": "1.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "dependencies": {
+        "@zxing/browser": "^0.1.5"
+      }
+    },
+    "node_modules/@zxing/browser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@zxing/browser/-/browser-0.1.5.tgz",
+      "integrity": "sha512-4Lmrn/il4+UNb87Gk8h1iWnhj39TASEHpd91CwwSJtY5u+wa0iH9qS0wNLAWbNVYXR66WmT5uiMhZ7oVTrKfxw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@zxing/text-encoding": "^0.9.0"
+      },
+      "peerDependencies": {
+        "@zxing/library": "^0.21.0"
+      }
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.21.3.tgz",
+      "integrity": "sha512-hZHqFe2JyH/ZxviJZosZjV+2s6EDSY0O24R+FQmlWZBZXP9IqMo7S3nb3+2LBWxodJQkSurdQGnqE7KXqrYgow==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ts-custom-error": "^3.2.1"
+      },
+      "engines": {
+        "node": ">= 10.4.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "license": "(Unlicense OR Apache-2.0)",
+      "optional": true
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,5 +13,7 @@
   "author": "",
   "license": "ISC",
   "type": "commonjs",
-  "dependencies": {}
+  "dependencies": {
+    "@zxing/browser": "^0.1.5"
+  }
 }

--- a/routes.py
+++ b/routes.py
@@ -168,6 +168,10 @@ def scanner():
 def barcode_demo():
     return render_template("index.html")
 
+@bp.route("/demo/zxing")
+def zxing_demo():
+    return render_template("pages/zxing_demo.html", title="ZXing Demo")
+
 @bp.route("/greet/<name>")
 def greet(name):
     return f"<p>Hello, {name}!</p>"

--- a/static/js/zxing-demo.js
+++ b/static/js/zxing-demo.js
@@ -1,0 +1,17 @@
+const resultInput = document.getElementById('zxing-result');
+const history = document.getElementById('zxing-history');
+
+function addToHistory(code) {
+  const div = document.createElement('div');
+  div.textContent = code;
+  history.prepend(div);
+}
+
+const codeReader = new ZXingBrowser.BrowserMultiFormatReader();
+codeReader.decodeFromVideoDevice(undefined, 'zxing-video', (result, err) => {
+  if (result) {
+    const text = result.getText();
+    resultInput.value = text;
+    addToHistory(text);
+  }
+});

--- a/templates/pages/zxing_demo.html
+++ b/templates/pages/zxing_demo.html
@@ -1,0 +1,13 @@
+{% include 'elements/header.html' %}
+<div class="container mx-auto px-4 flex flex-col h-[calc(100vh-4rem)]">
+  <h1 class="text-2xl font-bold mb-4">ZXing Barcode Scanner</h1>
+  <video id="zxing-video" class="w-full flex-grow"></video>
+  <div class="mt-4">
+    <label for="zxing-result" class="font-bold block mb-2">Last Scan:</label>
+    <input id="zxing-result" type="text" class="border p-1 w-full" readonly />
+  </div>
+  <div id="zxing-history" class="mt-4 h-40 overflow-y-auto border p-2"></div>
+</div>
+<script src="https://unpkg.com/@zxing/browser@latest"></script>
+<script src="{{ url_for('static', filename='js/zxing-demo.js') }}"></script>
+{% include 'elements/footer.html' %}


### PR DESCRIPTION
## Summary
- add `/demo/zxing` route serving new barcode scanner demo
- include ZXing browser library and demo page with camera scanning

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68928bcc27888327acc3652d8e4a59d7